### PR TITLE
[UI] 직관 기록 셀 변수 수정 / 최초 진입 화면 버튼 disabled 설정

### DIFF
--- a/Yanolja/Sources/DesignSystem/Views/Main/LargeVsTeamCell.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Main/LargeVsTeamCell.swift
@@ -36,7 +36,7 @@ struct LargeVsTeamCell: View {
               .padding(.bottom, 5)
             
             HStack{
-              Text("\(record.date.gameDate()) / \(record.stadiums.rawValue)")
+              Text("\(record.date.gameDate()) / \(record.stadiums.name)")
                 .font(.body)
                 .foregroundStyle(.black)
                 .padding(.leading, 20)

--- a/Yanolja/Sources/Screens/Main/MyTeamSelectView.swift
+++ b/Yanolja/Sources/Screens/Main/MyTeamSelectView.swift
@@ -61,6 +61,7 @@ struct MyTeamSelectView: View {
         }
       }
     )
+    .disabled(selectedTeam == nil)
     .padding(.horizontal, 16)
     .padding(.bottom, 41)
   }


### PR DESCRIPTION
# 요약
<img width="247" alt="스크린샷 2024-05-21 오후 2 27 39" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A11-YANOLJA/assets/122858647/e33b136f-2fd4-4785-8e5a-1c9dfdf45916">

- 직관 기록을 반영하는 셀에서의 경기장 정보의 반영 내용을 수정하였습니다.
- 20일 업로드했던 최초 진입 화면(온보딩 화면)의 Button disabled 관련 설정을 완료하였습니다.
- _(어제의 업보를 청산하였습니다 ✨)_

# LargeVsTeamCell 변수 수정
``` Swift
HStack{
    Text("\(record.date.gameDate()) / \(record.stadiums.name)")
      .font(.body)
      .foregroundStyle(.black)
      .padding(.leading, 20)
}
```
#### 기존의 코드는 `record.stadiums.rawValue`로 지정되어 있었으나, 해당 정보를 `record.stadiums.name`으로 수정하였습니다 ‼️
이전까지는 BaseballStadiums 내부에 구단 정보가 담기지 않았으나, 수정 확인 후 알맞게 교체하였습니다.

# MyTeamSelectView
``` Swift
Button(
  action: {
    // MARK: - 첫 화면으로 이동
  },
  label: {
    ZStack {
      RoundedRectangle(cornerRadius: 10)
        .foregroundColor(selectedTeam != nil ? .black : .gray)
        .frame(height: 48)
      Text("시작하기")
        .foregroundColor(.white)
        .font(.system(.headline, weight: .bold))
    }
  }
)
.disabled(selectedTeam == nil)
```

#### 코드를 수정함으로써 구단을 선택하지 않게 되면 버튼을 클릭할 수 없게 되었습니다 🥳
구단을 선택할 경우 해당 버튼은 활성화되며, 누를 경우 시작 화면으로 이동하게 됩니다.  ~_아직 연결하지 않았습니다_~

## 브리 한 마디
> 어제 마무리하지 않았던 내용에 대해 정리를 끝내서 마음이 후련합니다!
코딩을 하나 더 해서 재미있었어요!
스스로 한 것보다 보노에게 도움을 받은 게 더 컸지만...
보노가 도와줘서 앞으로 어떻게 해야 될지 배우게 된 것 같습니다 🎶
감사합니다 얼른 풀 받고 저의 업보를 가려주시죠!
![00a0e33f24b5c803df8152a3f22c5e55](https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A11-YANOLJA/assets/122858647/bab3a0c8-55ff-436c-bcd7-8b718c7b18cf)
