### PR TITLE
[UI] iPhone 13 미니 기준 최초 진입 화면 UI 수정

### DIFF
--- a/Yanolja/Sources/Screens/Main/MyTeamSelectView.swift
+++ b/Yanolja/Sources/Screens/Main/MyTeamSelectView.swift
@@ -38,11 +38,11 @@ struct MyTeamSelectView: View {
             )
           }
         )
-        .padding(.bottom, 16)
+        .padding(.bottom, 10)
       }
     }
     .padding(.horizontal, 16)
-    .padding(.top, 21)
+    .padding(.top, 10)
     
     Spacer()
     
@@ -63,7 +63,6 @@ struct MyTeamSelectView: View {
     )
     .disabled(selectedTeam == nil)
     .padding(.horizontal, 16)
-    .padding(.bottom, 41)
   }
 }
 


### PR DESCRIPTION
# MyTeamSelectView
![KakaoTalk_Photo_2024-05-21-15-07-56](https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A11-YANOLJA/assets/122858647/8a4fc180-0dbc-4da0-ba05-6c9dcfe3ba63) <img width="303" alt="KakaoTalk_Photo_2024-05-21-15-14-36" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A11-YANOLJA/assets/122858647/882a354d-aedf-49f9-adc1-355cb7a3cd71">

_화질 이슈 미안합니다🙏_
### 🔥 기존 디자인의 경우 iPhone 15 Pro 기준으로 작성되었기에 UI에 큰 문제가 없었지만, 사용자의 기종인 iPhone 13 mini에서 타이틀이 제대로 보이지 않는다는 치명적인 이슈 발견! 🔥

- padding 설정 때문이라고 판단, 하단 padding을 제거하고 최대한 iPhone 13 mini에서도 유사한 화면을 보일 수 있도록 조정하였습니다 :)
- 버튼 사이의 padding을 조정하였습니다 👍 예쁜 화면을 완성했어요!

## 이상입니다.
![image](https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A11-YANOLJA/assets/122858647/f14877a6-a5b6-4439-b4d4-efd83bdc0b5c)
