### PR TITLE
[UI] VsTeamDetailView padding 수정 / 직관 횟수 단위 추가

### DIFF
--- a/Yanolja/Sources/Screens/Main/VsTeamDetailView.swift
+++ b/Yanolja/Sources/Screens/Main/VsTeamDetailView.swift
@@ -56,6 +56,9 @@ struct VsTeamDetailView: View {
                   Text("--")
                     .font(.system(.largeTitle, weight: .bold))
                 }
+                
+                Text("회")
+                  .font(.subheadline)
               }
               .padding(.trailing, 16)
             }


### PR DESCRIPTION
# VsTeamDetailView
<img width="247" alt="스크린샷 2024-05-23 오후 12 52 30" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A11-YANOLJA/assets/122858647/d2d30735-c62c-4ca9-b106-3e3988ea9c27">
<img width="247" alt="스크린샷 2024-05-23 오후 12 59 34" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A11-YANOLJA/assets/122858647/623e3e38-af9f-4bd1-afda-57de72cc53cb">

- **_수정 전 (왼) ➡️ 수정 후 (오)_**
- VsTeamDetailView의 padding 관련 작은 수정사항 적용하였습니다.
- 직관 횟수의 단위가 사라진 것을 발견, 단위 다시 추가하였습니다.

## 브리 한 마디
> 한 마디를 적고는 싶은데 할 말이 없군요
오늘도 파이팅 야놀자 최고~