### PR TITLE
[Feat] 승률 상태별 캐릭터 애니메이션 추가, 캐릭터모델에서 승률 상태별 변수 프라비빗에서 일반변수로 변경

### DIFF
--- a/Yanolja/Sources/DesignSystem/Views/Main/MyCharacterView.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Main/MyCharacterView.swift
@@ -8,34 +8,131 @@
 
 import SwiftUI
 
+struct ShakingImageView: View {
+    @State private var isShaking = false
+    @State private var timer: Timer?
+    var image: Image
+
+    var body: some View {
+        image
+            .resizable()
+            .scaledToFit()
+            .aspectRatio(contentMode: .fit)
+            .offset(x: isShaking ? -10 : 0)
+            .animation(isShaking ?
+                Animation.linear(duration: 0.05).repeatForever(autoreverses: true) :
+                .default, value: isShaking)
+            .onAppear {
+                startShaking()
+            }
+            .onDisappear {
+                stopShaking()
+            }
+    }
+    
+    private func startShaking() {
+        timer = Timer.scheduledTimer(withTimeInterval: 1.3, repeats: true) { _ in
+            withAnimation {
+                isShaking.toggle()
+            }
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                withAnimation {
+                    isShaking.toggle()
+                }
+            }
+        }
+    }
+    
+    private func stopShaking() {
+        timer?.invalidate()
+        timer = nil
+    }
+}
+
+struct BouncingImageView: View {
+    @State private var isBouncing = false
+    var image: Image
+
+    var body: some View {
+        image
+            .resizable()
+            .scaledToFit()
+            .aspectRatio(contentMode: .fit)
+            .offset(y: isBouncing ? -20 : 35)
+            .animation(
+                Animation.easeInOut(duration: 1.4)
+                    .repeatForever(autoreverses: true),
+                value: isBouncing
+            )
+            .onAppear {
+                withAnimation {
+                    isBouncing.toggle()
+                }
+            }
+    }
+}
+
+struct ScalingImageView: View {
+    @State private var isScaled = false
+    var image: Image
+
+    var body: some View {
+        image
+            .resizable()
+            .scaledToFit()
+            .scaleEffect(isScaled ? 1.07 : 1.0)
+            .onAppear {
+                withAnimation(Animation.easeInOut(duration: 1.4).repeatForever(autoreverses: true)) {
+                    isScaled.toggle()
+                }
+            }
+    }
+}
+
+struct HappyImageView: View {
+    @State private var isHappy = false
+    var image: Image
+
+    var body: some View {
+        image
+            .resizable()
+            .scaledToFit()
+            .rotationEffect(.degrees(isHappy ? 15 : -15))
+            .scaleEffect(isHappy ? 1.08 : 1.0)
+            .onAppear {
+              withAnimation(Animation.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
+                    isHappy.toggle()
+                }
+            }
+    }
+}
+
 struct MyCharacterView: View {
   let characterModel: CharacterModel
-  @State private var isBouncing = false
-  
+
   var body: some View {
     VStack {
       BubbleTextView(
         text: characterModel.message
       )
       
-      characterModel.image
-        .resizable()
-        .scaledToFit()
-//        .offset(y: isBouncing ? -20 : 35)
-//        .onAppear {
-//            withAnimation(
-//              Animation.easeInOut(duration: 1.4)
-//                    .repeatForever(autoreverses: true)
-//            ) {
-//                isBouncing.toggle()
-//            }
-//        }
+      if characterModel.emotionByWinRate == .veryBad {
+          ScalingImageView(image: characterModel.image)
+      } else if characterModel.emotionByWinRate == .bad {
+          ShakingImageView(image: characterModel.image)
+      } else if characterModel.emotionByWinRate == .excellent {
+          HappyImageView(image: characterModel.image)
+      } else {
+          BouncingImageView(image: characterModel.image)
+      }
     }
   }
 }
 
+
 #Preview {
-  MyCharacterView(
-    characterModel: .init(myTeam: .kiwoom)
-  )
+    MyCharacterView(
+        characterModel: .init(myTeam: .kiwoom, totalWinRate: 75)
+    )
 }

--- a/Yanolja/Sources/Domain/Entity/CharacterModel.swift
+++ b/Yanolja/Sources/Domain/Entity/CharacterModel.swift
@@ -160,7 +160,7 @@ struct CharacterModel {
     }
   }
   
-  private var emotionByWinRate: CharacterEmotionType {
+  var emotionByWinRate: CharacterEmotionType {
     switch self.totalWinRate {
     case .none:
       return .none


### PR DESCRIPTION
# 승률 상태별 애니메이션 추가

<img width="893" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A11-YANOLJA/assets/145424895/18daa7f9-df5f-432b-b8d6-cfe21e26bb79">

아 근데 클로져 위치랑 줄 안맞췄어요...보노센세....죄송합니다......

+
<img width="370" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A11-YANOLJA/assets/145424895/0bb68ae9-ed9c-4382-9c97-5f91053e9ebb">
일반변수로 변경

## 에디의 한마디
![image](https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A11-YANOLJA/assets/145424895/cb8a20c4-eb87-4f20-a7c3-65cc097b4422)
철권 에디도 있답니다 여러분?