### PR TITLE
[UI] DetailRecordView 버튼 색상 변경

### DIFF
--- a/Yanolja/Sources/DesignSystem/Views/Record/SelectTeamView.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Record/SelectTeamView.swift
@@ -54,6 +54,7 @@ struct SelectTeamView: View {
             }
           }
         )
+        .accentColor(.gray)
         .labelsHidden()
       }
       

--- a/Yanolja/Sources/Screens/Record/DetailRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/DetailRecordView.swift
@@ -31,6 +31,9 @@ struct DetailRecordView: View {
     self.usecase = usecase
   }
   
+  let texts = ["a", "b", "c"]
+  @State private var selected: String = "a"
+  
   var body: some View {
     NavigationStack {
       List {
@@ -38,7 +41,6 @@ struct DetailRecordView: View {
           "직관 정보",
           content: {
             selectDate
-
             HStack(spacing: 10) {
               SelectTeamView(
                 type: .my,
@@ -52,6 +54,9 @@ struct DetailRecordView: View {
                 .font(.title2)
                 .foregroundStyle(.gray)
               
+              // 드는 의문점. 여기는 accentColor 안줘도 회색인데
+              // 경기장은 accentColor를 줘야만 회색으로 바뀜
+              // 자동으로 회색 picker가 된 이유가 뭘까?
               SelectTeamView(
                 type: .vs,
                 selectedTeam: recording.vsTeam,
@@ -60,6 +65,7 @@ struct DetailRecordView: View {
                 }
               )
             }
+            
             // 경기장 Picker
             Picker(
               "경기장",
@@ -69,7 +75,9 @@ struct DetailRecordView: View {
                 Text($0.name)
               }
             }
+            .accentColor(.gray)
             .pickerStyle(.menu)
+            
           }
         )
         // 직관 결과 선택 picker
@@ -79,15 +87,17 @@ struct DetailRecordView: View {
           }
         }
         .pickerStyle(.inline)
-        
-        
         if editType == .edit {
           Button(
             action: {
               usecase.effect(.tappedDeleteRecord(recording.id))
             },
             label: {
-              Text("삭제")
+              HStack{
+                Spacer()
+                Text("기록 삭제").foregroundStyle(.red)
+                Spacer()
+              }
             }
           )
         }
@@ -105,7 +115,7 @@ struct DetailRecordView: View {
                 }
               },
               label: {
-                Text("완료")
+                Text("완료").bold()
               }
             )
           }
@@ -121,7 +131,6 @@ struct DetailRecordView: View {
               },
               label: {
                 Text("취소")
-                  .foregroundStyle(.red)
               }
             )
           }


### PR DESCRIPTION
# 요약
   
   
* 이번 작업은 버튼 색상 등의 UI를 변경했습니다.
   
<img width="306" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A11-YANOLJA/assets/87603379/3cb94723-0639-43fc-acaf-1771048a041b">
   
   
1. 기존에 취소 버튼이 빨간색이던 것을 다시 기본 색상으로 변경했습니다.
2. 삭제 버튼 ➡️ "기록 삭제" 로 변경하고, 색상을 빨간색으로 변경했습니다.
   
   
# 필요한 부분
    
* 나의팀, 상대팀을 선택하는 부분이 터치가 이상해요... 이거 변경해서 올게요... 찾아보겠습니다
   
# 고스트 한마디
   
크게 달라진 부분이 없어서 할 말이 많이 없어용
일단 고쳐야 할 부분을 얼른 찾아보고 오겠습니다.

![image](https://github.com/DeveloperAcademy-POSTECH/2024-MC2-A11-YANOLJA/assets/87603379/7a6374cd-d834-46d2-8bb1-bd2a60979afc)
