### PR TITLE
[UI] VsTeamDetailView ScrollView 추가

### DIFF
--- a/Yanolja/Sources/Screens/Main/VsTeamDetailView.swift
+++ b/Yanolja/Sources/Screens/Main/VsTeamDetailView.swift
@@ -128,35 +128,39 @@ struct VsTeamDetailView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .padding(.horizontal, 16)
       } else {
-        VStack {
-          ForEach(
-            recordUseCase
-              .state
-              .recordList
-              .filter{ list in
-                list.vsTeam == detailTeam
-              },
-            id: \.id
-          ) { list in
-            NavigationLink(
-              destination: {
-                DetailRecordView(
-                  to: .edit,
-                  record: list,
-                  usecase: recordUseCase,
-                  changeRecords: { updateRecords in winRateUseCase.effect(.updateRecords(updateRecords))
-                  }
-                )
-                .navigationBarBackButtonHidden()
-              },
-              label: {
-                LargeVsTeamCell(record: list)
-              }
-            )
+        ScrollView() {
+          VStack {
+            ForEach(
+              recordUseCase
+                .state
+                .recordList
+                .filter{ list in
+                  list.vsTeam == detailTeam
+                },
+              id: \.id
+            ) { list in
+              NavigationLink(
+                destination: {
+                  DetailRecordView(
+                    to: .edit,
+                    record: list,
+                    usecase: recordUseCase,
+                    changeRecords: { updateRecords in
+                      winRateUseCase.effect(.updateRecords(updateRecords)
+                      )
+                    }
+                  )
+                  .navigationBarBackButtonHidden()
+                },
+                label: {
+                  LargeVsTeamCell(record: list)
+                }
+              )
+            }
+            Spacer()
           }
-          Spacer()
+          .padding(.horizontal, 16)
         }
-        .padding(.horizontal, 16)
       }
     }
   }


### PR DESCRIPTION
# VsTeamDetailView
``` Swift
ScrollView() {
    VStack {
         ForEach(
             recordUseCase
                .state
                .recordList
                .filter{ list in
                  list.vsTeam == detailTeam
                },
              id: \.id
        ) { ... }
   ...
}
```

- List를 Stack으로 바꾼 뒤 사라진 ScrollView를 따로 적용하였습니다 ✨
- 아이템이 여러 개 추가되었을 때 Scroll이 가능해졌어요!

### 이상입니다.