### PR TITLE
[💄UI] TabBar 아이콘 변경

### DIFF
--- a/Yanolja/Sources/App/AppView.swift
+++ b/Yanolja/Sources/App/AppView.swift
@@ -27,7 +27,9 @@ struct AppView: View {
           userInfoUseCase: userInfoUseCase
         )
         .tabItem {
-          Image(systemName: "1.square.fill")
+          Image(systemName: "house")
+          // SFsymbol이 자동으로 .fill 처리되는 것 제어
+            .environment(\.symbolVariants, .none)
           Text("홈")
         }
         .tag(Tab.main)
@@ -38,7 +40,9 @@ struct AppView: View {
           selectedYearFilter: $selectedRecordYearFilter
         )
         .tabItem {
-          Image(systemName: "2.square.fill")
+          Image(systemName: "plus.app")
+          // SFsymbol이 자동으로 .fill 처리되는 것 제어
+            .environment(\.symbolVariants, .none)
           Text("기록")
         }
         .tag(Tab.record)
@@ -51,7 +55,7 @@ struct AppView: View {
         )
         .tag(Tab.analyze)
         .tabItem {
-          Image(systemName: "3.square.fill")
+          Image(systemName: "chart.line.uptrend.xyaxis")
           Text("분석")
         }
       }


### PR DESCRIPTION
## 간단하게 바뀐 것
<img src="https://github.com/user-attachments/assets/1ac5c265-d2b6-4aa7-aa03-8b26060dc516" alt="Simulator Screenshot" width="350"/>

- 아이콘을 바꿨습니다! 아까 한 번에 할 생각이었는데 잠시 깜빡했어요...
- 그리고 Config 파일 오류 없나 해서 확인차 보내는 겁니당.
- 놀라운 점이 있다면 `Image(systemName: "house")`라고만 하면 자연스럽게 `house.fill` 아이콘이 뜹니다. 근데 종종 있던 현상이었나 보더라고요? 애플 개발자 페이지에 같은 사람이 있어서 코드 수정했습니당. 혹시 몰라서 헤헷
``` Swift
Image(systemName: "house")
     // SFsymbol이 자동으로 .fill 처리되는 것 제어
     .environment(\.symbolVariants, .none)
```
신기티비...

## 부리의 어리석은 한 마디
> 아... 일요일 안에 쌉가능인데?