### PR TITLE
[✨ Feat] RecordCell SSG 선택 시 프레임 수정 / DetailRecordView 점수 미입력 시 0점 처리 / 사진 삭제 구현

### DIFF
--- a/Yanolja/Sources/DesignSystem/Views/Record/RecordCell.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Record/RecordCell.swift
@@ -29,12 +29,12 @@ struct RecordCell: View {
           }
           Spacer()
           VStack {
-            HStack(spacing: 8) {
+            HStack(spacing: 6) {
               Text(record.myTeam.name.split(separator: " ").first ?? "")
                 .font(.title)
                 .bold()
                 .foregroundStyle(.black)
-                .frame(width: 50)
+                .frame(width: 60)
               Text("vs")
                 .font(.subheadline)
                 .foregroundStyle(.gray)
@@ -42,7 +42,7 @@ struct RecordCell: View {
                 .font(.title)
                 .foregroundStyle(.black)
                 .bold()
-                .frame(width: 50)
+                .frame(width: 60)
             }
             .padding(.bottom, 2)
             

--- a/Yanolja/Sources/DesignSystem/Views/Record/RecordCell.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Record/RecordCell.swift
@@ -29,20 +29,23 @@ struct RecordCell: View {
           }
           Spacer()
           VStack {
-            HStack(spacing: 6) {
+            HStack(spacing: 0) {
               Text(record.myTeam.name.split(separator: " ").first ?? "")
                 .font(.title)
                 .bold()
                 .foregroundStyle(.black)
-                .frame(width: 60)
+                .frame(width: 70)
+                .multilineTextAlignment(.trailing)
               Text("vs")
                 .font(.subheadline)
                 .foregroundStyle(.gray)
+                .frame(width: 16)
               Text(record.vsTeam.name.split(separator: " ").first ?? "")
                 .font(.title)
                 .foregroundStyle(.black)
                 .bold()
-                .frame(width: 60)
+                .frame(width: 70)
+                .multilineTextAlignment(.leading)
             }
             .padding(.bottom, 2)
             

--- a/Yanolja/Sources/Screens/Record/DetailRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/DetailRecordView.swift
@@ -157,7 +157,7 @@ struct DetailRecordView: View {
                 "--",
                 text: Binding(
                   get: {
-                    recording.myTeamScore.isEmpty || recording.myTeamScore == "--" ? "" : recording.myTeamScore
+                    recording.myTeamScore == "--" ? "" : recording.myTeamScore
                   },
                   set: { newValue in
                     recording.myTeamScore = newValue.isEmpty ? "" : newValue
@@ -179,7 +179,7 @@ struct DetailRecordView: View {
                 "--",
                 text: Binding(
                   get: {
-                    recording.vsTeamScore.isEmpty || recording.vsTeamScore == "--" ? "" : recording.vsTeamScore
+                    recording.vsTeamScore == "--" ? "" : recording.vsTeamScore
                   },
                   set: { newValue in
                     recording.vsTeamScore = newValue.isEmpty ? "" : newValue
@@ -286,10 +286,10 @@ struct DetailRecordView: View {
                 if editType == .create { // 생성 시
                   // 만약 스코어를 입력하지 않고 저장했다면 리스트에 "--" 반영
                   if recording.myTeamScore.isEmpty {
-                    recording.myTeamScore = "--"
+                    recording.myTeamScore = "0"
                   }
                   if recording.vsTeamScore.isEmpty {
-                    recording.vsTeamScore = "--"
+                    recording.vsTeamScore = "0"
                   }
                   if recording.isCancel {
                     recording.isCancel = true
@@ -300,10 +300,10 @@ struct DetailRecordView: View {
                 } else { // 수정 시
                   // 만약 스코어를 입력하지 않고 저장했다면 리스트에 "--" 반영
                   if recording.myTeamScore.isEmpty {
-                    recording.myTeamScore = "--"
+                    recording.myTeamScore = "0"
                   }
                   if recording.vsTeamScore.isEmpty {
-                    recording.vsTeamScore = "--"
+                    recording.vsTeamScore = "0"
                   }
                   if recording.isCancel {
                     recording.isCancel = true

--- a/Yanolja/Sources/Screens/Record/DetailRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/DetailRecordView.swift
@@ -35,6 +35,8 @@ struct DetailRecordView: View {
   @State private var selectedUIImage: UIImage?
   @State private var image: Image?
   
+  @State private var makeBlur: Bool = false
+  
   init(
     to editType: RecordViewEditType,
     record: GameRecordWithScoreModel = .init(),
@@ -232,14 +234,38 @@ struct DetailRecordView: View {
           content: {
             if let image = recording.photo {
               VStack {
-                image
-                  .resizable()
-                  .scaledToFill()
-                  .frame(width: UIScreen.main.bounds.width - 50, height: UIScreen.main.bounds.width - 50)
-                  .clipped()
-                  .cornerRadius(8)
+                if makeBlur {
+                  ZStack {
+                    image
+                      .resizable()
+                      .scaledToFill()
+                      .frame(width: UIScreen.main.bounds.width - 50, height: UIScreen.main.bounds.width - 50)
+                      .clipped()
+                      .cornerRadius(8)
+                      .blur(radius: 3)
+                    Image(systemName: "trash")
+                      .resizable()
+                      .frame(width: 36, height: 42)
+                      .aspectRatio(1, contentMode: .fill)
+                      .foregroundStyle(.white)
+                      .onTapGesture {
+                        recording.photo = nil
+                        makeBlur.toggle()
+                      }
+                  }
+                } else {
+                  image
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: UIScreen.main.bounds.width - 50, height: UIScreen.main.bounds.width - 50)
+                    .clipped()
+                    .cornerRadius(8)
+                }
               }
               .frame(height: UIScreen.main.bounds.width - 50)
+              .onTapGesture {
+                makeBlur.toggle()
+              }
             } else {
               HStack(spacing: 0) {
                 Image(systemName: "plus")


### PR DESCRIPTION
## RecordCell

<img width="294" alt="스크린샷 2024-10-08 오전 2 11 12" src="https://github.com/user-attachments/assets/22c94ea3-f06a-4b36-ab52-07d2b1d65c83">

- 저번 PR에서 보았던 SSG 선택 시 구단 이름이 밀리는 현상을 반영해 구단 이름 프레임을 수정하였습니당.
- SSG 기준으로 맞출 경우에 타구단 선택 시 정렬이 맞지 않아 SSG가 이해해 주기로 했습니다 ^___^

## DetailRecordView

- 기존에는 점수를 입력하지 않고 저장할 경우 "--"으로 저장했었는데, 취소된 경기와 혼돈이 있을 것 같아 0점으로 반영하도록 코드를 수정하였습니다
- 점수 미입력 시 0점으로 반영되며, 수정창으로 들어가면 0점으로 보입니다!
``` Swift
if recording.myTeamScore.isEmpty {
  recording.myTeamScore = "0"
}
if recording.vsTeamScore.isEmpty {
  recording.vsTeamScore = "0"
}
```

- 기록 저장 시 사진 선택 후, **해당 사진을 삭제하고 다른 사진을 업로드할 수 있도록** 구현하였습니당 😎
<img width="250" alt="스크린샷 2024-10-08 오전 2 11 12" src="https://github.com/user-attachments/assets/7c37e8ff-5f11-4e10-a094-760df9153ca9">
<img width="250" alt="스크린샷 2024-10-08 오전 2 11 12" src="https://github.com/user-attachments/assets/76fea28d-e0a6-4551-8128-f4b8d9b68050">
<img width="250" alt="스크린샷 2024-10-08 오전 2 11 12" src="https://github.com/user-attachments/assets/71bfbd7a-e28c-42d3-a962-a011d3be052b">


## 브리 한 마디
> 다들 수고가 많으십니당. 빠이팅!
> 오랜만에 너무 재밌어요 🥹

![image](https://github.com/user-attachments/assets/8872ec6e-f8a7-41a7-99c2-6c27a98d5727)
