### PR TITLE
[💄UI] MyCharacterView 말풍선 뷰 구현

### DIFF
--- a/Yanolja/Sources/DesignSystem/Views/Main/MyCharacterView.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Main/MyCharacterView.swift
@@ -11,43 +11,117 @@ import SwiftUI
 struct MainCharacterView: View {
   let characterModel: CharacterModel
   
+  @State private var isVisible: [Bool] = [false, false, false, false, false]
+  @State private var isAnimating: [Bool] = [false, false, false, false, false]
+  private let maxCount = 5
+  
+  // 확인을 위한 예시
+  private let bubbleText: [String] = ["최 강 두 산", "두산의 승리를 위하여 🎶", "우리가 왔어 허슬두", "두산 그대의 이름은 승리", "해냈다 해냈어 두산이 해냈어"]
+  
   var body: some View {
     VStack {
       ZStack {
-        switch characterModel.emotionByWinRate {
-        case .none:
-          Image(.mainCharacter0Background)
-          Image(.mainCharacter0Face)
-            .renderingMode(.template)
-          Image(.mainCharacter0Line)
-          VStack {
-            Spacer()
-            Image(.mainCharacter0Shadow)
+        ZStack {
+          switch characterModel.emotionByWinRate {
+          case .none:
+            Image(.mainCharacter0Background)
+            Image(.mainCharacter0Face)
+              .renderingMode(.template)
+            Image(.mainCharacter0Line)
+            VStack {
+              Spacer()
+              Image(.mainCharacter0Shadow)
+            }
+            .frame(height: 280)
+          case .veryBad:
+            Image(.mainCharacter1Background)
+            Image(.mainCharacter1Face)
+              .renderingMode(.template)
+            Image(.mainCharacter1Line)
+          case .bad:
+            Image(.mainCharacter2Background)
+            Image(.mainCharacter2Face)
+              .renderingMode(.template)
+            Image(.mainCharacter2Line)
+          case .good:
+            Image(.mainCharacter3Background)
+            Image(.mainCharacter3Face)
+              .renderingMode(.template)
+            Image(.mainCharacter3Line)
+          case .excellent:
+            Image(.mainCharacter4Background)
+            Image(.mainCharacter4Face)
+              .renderingMode(.template)
+            Image(.mainCharacter4Line)
           }
-          .frame(height: 280)
-        case .veryBad:
-          Image(.mainCharacter1Background)
-          Image(.mainCharacter1Face)
-            .renderingMode(.template)
-          Image(.mainCharacter1Line)
-        case .bad:
-          Image(.mainCharacter2Background)
-          Image(.mainCharacter2Face)
-            .renderingMode(.template)
-          Image(.mainCharacter2Line)
-        case .good:
-          Image(.mainCharacter3Background)
-          Image(.mainCharacter3Face)
-            .renderingMode(.template)
-          Image(.mainCharacter3Line)
-        case .excellent:
-          Image(.mainCharacter4Background)
-          Image(.mainCharacter4Face)
-            .renderingMode(.template)
-          Image(.mainCharacter4Line)
+        }
+        .foregroundColor(characterModel.myTeam.mainColor)
+        
+        GeometryReader { geometry in
+          ForEach(0..<bubbleText.count, id: \.self) { index in
+            if isVisible[index] {
+              makeBubble(text: bubbleText[index])
+                .position(getPosition(for: index, in: geometry.size))
+                .opacity(isAnimating[index] ? 1 : 0)
+                .animation(.easeInOut(duration: 0.5), value: isAnimating[index])
+            }
+          }
         }
       }
-      .foregroundColor(characterModel.myTeam.mainColor)
+    }
+    .onTapGesture {
+      showNextBubble()
+    }
+  }
+  
+  func makeBubble(text: String) -> some View {
+    Text(text)
+      .font(.footnote)
+      .padding(.horizontal, 16)
+      .padding(.vertical, 8)
+      .background(
+        RoundedRectangle(cornerRadius: 20)
+          .foregroundStyle(.bubble)
+          .opacity(0.8)
+      )
+  }
+  
+  func showNextBubble() {
+    for i in 0..<isVisible.count {
+      if !isVisible[i] {
+        isVisible[i] = true
+        withAnimation {
+          isAnimating[i] = true
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+          withAnimation {
+            isAnimating[i] = false
+          }
+          
+          DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            isVisible[i] = false
+          }
+        }
+        break
+      }
+    }
+  }
+  
+  /// 기기의 사이즈를 고려하여 말풍선 배치
+  func getPosition(for index: Int, in size: CGSize) -> CGPoint {
+    switch index {
+    case 0:
+      return CGPoint(x: size.width * 0.23, y: size.height * 0.1)
+    case 1:
+      return CGPoint(x: size.width * 0.77, y: size.height * 0.53)
+    case 2:
+      return CGPoint(x: size.width * 0.38, y: size.height * 0.73)
+    case 3:
+      return CGPoint(x: size.width * 0.46, y: size.height * 0.23)
+    case 4:
+      return CGPoint(x: size.width * 0.65, y: size.height * 0.86)
+    default:
+      return CGPoint(x: size.width / 2, y: size.height / 2)
     }
   }
 }

--- a/Yanolja/Sources/DesignSystem/Views/Record/RecordCell.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Record/RecordCell.swift
@@ -15,9 +15,9 @@ struct RecordCell: View {
     ZStack {
       VStack {
         HStack(spacing: 0) {
-          // 경기가 취소되었을 경우 점수가 아닌 "--"로 표시
+          // 경기가 취소되었을 경우 점수가 아닌 "-"로 표시
           if record.isCancel {
-            Text("--")
+            Text("-")
               .jikyoFont(.recordCell)
               .foregroundStyle(myTeamScoreColor())
               .frame(width: 70, height: 70)
@@ -58,9 +58,9 @@ struct RecordCell: View {
           }
           Spacer()
           ZStack(alignment: .center) {
-            // 경기가 취소되었을 경우 점수가 아닌 "--"로 표시
+            // 경기가 취소되었을 경우 점수가 아닌 "-"로 표시
             if record.isCancel {
-              Text("--")
+              Text("-")
                 .jikyoFont(.recordCell)
                 .foregroundStyle(vsTeamScoreColor())
                 .frame(width: 70, height: 70)
@@ -96,33 +96,33 @@ struct RecordCell: View {
   
   func myTeamScoreColor() -> Color {
     guard !record.isCancel else {
-      return .gray
+      return Color(.systemGray4)
     }
     switch record.result {
     case .win:
       return record.myTeam.mainColor
     case .lose:
-      return .gray
+      return Color(.systemGray4)
     case .draw:
-      return .gray
+      return Color(.systemGray4)
     case .cancel:
-      return .gray
+      return Color(.systemGray4)
     }
   }
   
   func vsTeamScoreColor() -> Color {
     guard !record.isCancel else {
-      return .gray
+      return Color(.systemGray4)
     }
     switch record.result {
     case .win:
-      return .gray
+      return Color(.systemGray4)
     case .lose:
       return .gray
     case .draw:
-      return .gray
+      return Color(.systemGray4)
     case .cancel:
-      return .gray
+      return Color(.systemGray4)
     }
   }
 }

--- a/Yanolja/Sources/Screens/Record/DetailRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/DetailRecordView.swift
@@ -237,7 +237,7 @@ struct DetailRecordView: View {
               VStack {
                 if makeBlur {
                   ZStack {
-                    image
+                    Image(uiImage: image)
                       .resizable()
                       .scaledToFill()
                       .frame(width: UIScreen.main.bounds.width - 50, height: UIScreen.main.bounds.width - 50)
@@ -255,7 +255,7 @@ struct DetailRecordView: View {
                       }
                   }
                 } else {
-                  image
+                  Image(uiImage: image)
                     .resizable()
                     .scaledToFill()
                     .frame(width: UIScreen.main.bounds.width - 50, height: UIScreen.main.bounds.width - 50)


### PR DESCRIPTION
## 구현 내용
<img src="https://github.com/user-attachments/assets/82fb813c-7d78-43f7-b9f6-61e3f8f38337" alt="Simulator Screenshot" width="300"/>

- 캐릭터를 막 누르면 무한으로 말풍선이 튀어나옵니다 ✨
- 위치를 지정해 준 로셸 선생님께 감사의 말씀을 드립니다... 최고로셸 🥹

## MyCharacterView

- 애니메이션을 적용하는 과정에서 isVisible에 의존해서 애니메이션을 부여하니까 애니메이션이 들어갈 타이밍에 Visible이 조정이 되어 애니메이션을 볼 수 없더라구요...
- 그래서 isAnimating이라는 애니메이션을 위한 Bool 배열을 따로 만들었습니당.
- 현재 말풍선의 위치는 `GeometryReader`를 활용해서 최대한 모든 기기에서 비슷하게 보이도록 잡아 뒀습니당. 근데 iPhone mini가 많이 작다 보니 mini보다 큰 모델에서는 말풍선이 오밀조밀 모여있는 형태이긴 합니다 🫠
- **‼️우선은 임시 배열을 사용한 상태입니다‼️**

``` Swift
func showNextBubble() {
    for i in 0..<isVisible.count {
      if !isVisible[i] {
        isVisible[i] = true
        withAnimation {
          isAnimating[i] = true
        }
        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
          withAnimation {
            isAnimating[i] = false
          }
          
          DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
            isVisible[i] = false
          }
        }
        break
      }
    }
  }
```

## 부리 한 마디
> 헤헷 커밋 메세지를 잘못 썼다는 걸 푸시한 뒤에 알았씁니다 ^___^ 하지만 내용에는 크게 문제가 없으니 force 처리를 할 감은 절대. 아니라고 생각해서 구냥 그대로 둡니당. 올릴 때 더 잘 보겠슴둥.. 다들 감사합니다 ☺️

![image](https://github.com/user-attachments/assets/dd057204-91bf-49fb-ab5a-e918065a3c27)
