### PR TITLE
[💄UI] RecordCell 취소 경기에 대해 disabled처럼 보이도록 수정 / 더블헤더 경기 UI 반영

### DIFF
--- a/Yanolja/Sources/DesignSystem/Views/Record/RecordCell.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Record/RecordCell.swift
@@ -53,10 +53,23 @@ struct RecordCell: View {
             }
             .padding(.bottom, 2)
             
-            Text(record.date.gameDate())
-              .font(.caption2)
-              .opacity(record.isCancel ? 0.5 : 1)
-              .foregroundStyle(.date)
+            switch record.isDoubleHeader {
+            case 1:
+              Text("\(record.date.gameDate()) DH1")
+                .font(.caption2)
+                .opacity(record.isCancel ? 0.5 : 1)
+                .foregroundStyle(.date)
+            case 2:
+              Text("\(record.date.gameDate()) DH2")
+                .font(.caption2)
+                .opacity(record.isCancel ? 0.5 : 1)
+                .foregroundStyle(.date)
+            default:
+              Text(record.date.gameDate())
+                .font(.caption2)
+                .opacity(record.isCancel ? 0.5 : 1)
+                .foregroundStyle(.date)
+            }
             Text(record.stadiums)
               .font(.caption2)
               .opacity(record.isCancel ? 0.5 : 1)

--- a/Yanolja/Sources/DesignSystem/Views/Record/RecordCell.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Record/RecordCell.swift
@@ -20,6 +20,7 @@ struct RecordCell: View {
             Text("-")
               .jikyoFont(.recordCell)
               .foregroundStyle(myTeamScoreColor())
+              .opacity(0.5)
               .frame(width: 70, height: 70)
           } else {
             Text(record.myTeamScore)
@@ -34,16 +35,19 @@ struct RecordCell: View {
                 .font(.title)
                 .bold()
                 .foregroundStyle(.black)
+                .opacity(record.isCancel ? 0.5 : 1)
                 .frame(width: 70)
                 .multilineTextAlignment(.trailing)
               Text("vs")
                 .font(.subheadline)
                 .foregroundStyle(.gray)
+                .opacity(record.isCancel ? 0.5 : 1)
                 .frame(width: 16)
               Text(record.vsTeam.name.split(separator: " ").first ?? "")
                 .font(.title)
                 .foregroundStyle(.black)
                 .bold()
+                .opacity(record.isCancel ? 0.5 : 1)
                 .frame(width: 70)
                 .multilineTextAlignment(.leading)
             }
@@ -51,9 +55,11 @@ struct RecordCell: View {
             
             Text(record.date.gameDate())
               .font(.caption2)
+              .opacity(record.isCancel ? 0.5 : 1)
               .foregroundStyle(.date)
             Text(record.stadiums)
               .font(.caption2)
+              .opacity(record.isCancel ? 0.5 : 1)
               .foregroundStyle(.date)
           }
           Spacer()
@@ -63,6 +69,7 @@ struct RecordCell: View {
               Text("-")
                 .jikyoFont(.recordCell)
                 .foregroundStyle(vsTeamScoreColor())
+                .opacity(0.5)
                 .frame(width: 70, height: 70)
             } else {
               Text(record.vsTeamScore)
@@ -78,6 +85,7 @@ struct RecordCell: View {
       .background(
         RoundedRectangle(cornerRadius: 16)
           .fill(.bg)
+          .opacity(record.isCancel ? 0.5 : 1)
       )
       
       Path { path in
@@ -89,6 +97,7 @@ struct RecordCell: View {
         Color.init(hex: 0xC7C7CC)
           .opacity(0.35)
       )
+      .opacity(record.isCancel ? 0.5 : 1)
       .frame(width: 2, height: 118)
     }
     


### PR DESCRIPTION
## 취소 경기 반영
<img width="265" alt="스크린샷 2024-10-11 오후 1 27 31" src="https://github.com/user-attachments/assets/b9895609-190a-49c9-822d-83dfbe8f318a">

- 경기가 취소되었을 경우 disabled 처리가 된 것처럼 수정하였습니다!
- 해당 경기를 삭제하고 싶을 경우 수정창을 거쳐야 하기에 실제로 disabled 처리가 되어있지는 않습니다 ✨

## 더블헤더 표현
<img width="265" alt="스크린샷 2024-10-11 오후 1 30 12" src="https://github.com/user-attachments/assets/3c47ef2b-eb95-4c90-83d7-3311ad097f90">

- 더블헤더 경기의 경우 날짜 옆에 DH0과 같은 형식이 반영됩니다!
- 더블헤더 경기가 아닐 경우에는 기존 디자인과 동일하게 날짜만 표시됩니다 😎

``` Swift
switch record.isDoubleHeader {
    case 1:
      Text("\(record.date.gameDate()) DH1")
        .font(.caption2)
        .opacity(record.isCancel ? 0.5 : 1)
        .foregroundStyle(.date)
     case 2:
       Text("\(record.date.gameDate()) DH2")
         .font(.caption2)
         .opacity(record.isCancel ? 0.5 : 1)
         .foregroundStyle(.date)
     default:
       Text(record.date.gameDate())
         .font(.caption2)
         .opacity(record.isCancel ? 0.5 : 1)
         .foregroundStyle(.date)
}
```

_약간 고민되는 게 있다면 코드를 조금 더 간단하게 만들 수 있을까에 대한 고민..._

## 부리 한 마디
> 수고하셨슴둥 마지막까지 파이팅 ✨🔥

![image](https://github.com/user-attachments/assets/b8e7238b-d960-4d9c-8a1a-332da7a46a5d)
