### PR TITLE
[🔥HOTFIX] 취소 경기가 무승부 필터에서 발견되는 문제 해결

### DIFF
--- a/Yanolja/Sources/Domain/Entity/RecordModel.swift
+++ b/Yanolja/Sources/Domain/Entity/RecordModel.swift
@@ -79,7 +79,7 @@ struct GameRecordWithScoreModel: Identifiable {
   }
   
   var result: GameResult { // 계산 속성으로 변경
-    guard let myTeamScore = Int(myTeamScore), let vsTeamScore = Int(vsTeamScore) else { return .cancel }
+    guard !self.isCancel else { return .cancel }
     if myTeamScore > vsTeamScore {
       return .win
     } else if myTeamScore < vsTeamScore {


### PR DESCRIPTION
# 문제원인 
취소 경기에서 스코어를 매길 수 있으므로 취소 경기가 무승부 경기로 기록되는 문제가 있었습니다 

# 해결 
```swift
  var result: GameResult { // 계산 속성으로 변경
    guard let myTeamScore = Int(myTeamScore), let vsTeamScore = Int(vsTeamScore) else { return .cancel } // 삭제 
    guard !self.isCancel else { return .cancel } // 추가 
    if myTeamScore > vsTeamScore {
      return .win
    } else if myTeamScore < vsTeamScore {
```

### 보노 한 마디  

![image](https://github.com/user-attachments/assets/08efec03-dfcb-42d4-960f-3e3fb05ea3f7)
문제를 발견한 부리부부리 최고!! 
