### PR TITLE
[🔥HOTFIX] DetailRecordView 키보드 return 시 텍스트 사라지는 문제 해결 / AllRecordView 연도별 기록 확인 시 기록이 없음에도 불구하고 직관 기록 없음 문구가 뜨지 않는 오류 수정

### DIFF
--- a/Yanolja/Sources/App/AppView.swift
+++ b/Yanolja/Sources/App/AppView.swift
@@ -63,7 +63,7 @@ struct AppView: View {
           switch selection {
           case .main: return "나의 직관 승률"
           case .record: return "\(selectedRecordYearFilter) 직관 기록"
-          case .analytics: return "\(winRateUseCase.state.selectedYearFilter) 직관 분석"
+          case .analytics: return "\(winRateUseCase.state.selectedYearFilter) 승률 분석"
           }
         }()
       )

--- a/Yanolja/Sources/Screens/Analyze/AllAnalyticsView.swift
+++ b/Yanolja/Sources/Screens/Analyze/AllAnalyticsView.swift
@@ -54,7 +54,7 @@ struct AllAnalyticsView: View {
         }
         
         VStack(alignment: .leading, spacing: 8) {
-          Text("나의 승률")
+          Text("나의 직관 승률")
             .font(.footnote)
           HStack {
             Spacer()

--- a/Yanolja/Sources/Screens/Analyze/AnalyticsDetailView.swift
+++ b/Yanolja/Sources/Screens/Analyze/AnalyticsDetailView.swift
@@ -77,7 +77,7 @@ struct AnalyticsDetailView: View {
           VStack(alignment: .leading, spacing: 8) {
             Text("직관 승률")
               .font(.footnote)
-            HStack {
+            HStack(spacing: 0) {
               Spacer()
               if let winRate {
                 Text("\(String(winRate))")

--- a/Yanolja/Sources/Screens/Record/AllRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/AllRecordView.swift
@@ -74,6 +74,7 @@ struct AllRecordView: View {
             )
           }
         }
+        .scrollIndicators(.never)
         .padding(.top, 25)
       }
     }

--- a/Yanolja/Sources/Screens/Record/AllRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/AllRecordView.swift
@@ -44,6 +44,7 @@ struct AllRecordView: View {
       }
       
       if recordUseCase.state.recordList
+        .filtered(years: selectedYearFilter)
         .filtered(options: selectedRecordFilter)
         .sortByLatestDate(isAscending).isEmpty {
         HStack{

--- a/Yanolja/Sources/Screens/Record/DetailRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/DetailRecordView.swift
@@ -30,8 +30,6 @@ struct DetailRecordView: View {
   @State private var selectedOption: String = ""
   let doubleHeader = [0: "DH1", 1: "DH2"]
   
-  @State private var inputText = ""
-  
   @State private var showImagePicker = false
   @State private var selectedUIImage: UIImage?
   @State private var image: Image?
@@ -165,7 +163,7 @@ struct DetailRecordView: View {
                   set: { newValue in
                     recording.myTeamScore = newValue.isEmpty ? "" : newValue
                   }))
-              .keyboardType(.numberPad) 
+              .keyboardType(.numberPad)
               .multilineTextAlignment(.center)
               .frame(width: 94, height: 32)
               .background(
@@ -224,9 +222,6 @@ struct DetailRecordView: View {
               if newValue.count > 15 {
                 recording.memo = String(newValue.prefix(15))
               }
-            }
-            .onSubmit {
-              recording.memo = inputText
             }
           })
         

--- a/Yanolja/Sources/Screens/Settings/SettingsView.swift
+++ b/Yanolja/Sources/Screens/Settings/SettingsView.swift
@@ -62,6 +62,9 @@ struct ContentView: View {
       VStack(spacing: 12) {
         ZStack {
           Circle()
+            .foregroundStyle(.white)
+            .frame(width: 120)
+          Circle()
             .stroke(lineWidth: 1)
             .frame(width: 120)
           ZStack {


### PR DESCRIPTION
## 문제 상황
1. DetailRecordView에서 TextField 입력 후 키보드에서 return 버튼을 누르면 TextField의 텍스트가 사라지는 문제가 있었습니당.
2. AllRecordView에서 한 연도 기록이 있을 경우, 다른 연도 기록을 확인했을 때 '직관 기록이 없습니다'라는 문구가 뜨지 않았습니다!

## 해결
1.
- 이전에 삭제하지 않은 `onSubmit` 코드가 남아있었습니다!! 사용하지 않는 변수를 `""`로 초기화해 뒀는데, 해당 값을 계속해서 `recording.memo`에 집어넣게 되어 해당 오류가 발생하였습니당
- **onSubmit** 코드를 삭제하면서 해결하였습니다!!

2.
``` Swift
if recordUseCase.state.recordList
        .filtered(years: selectedYearFilter) // 이 코드가 추가되어 있지 않았습니다!
        .filtered(options: selectedRecordFilter)
        .sortByLatestDate(isAscending).isEmpty {
        HStack{
          Spacer()
          Text("직관 기록이 없습니다. \n직관 기록을 추가하세요!")
            .multilineTextAlignment(.center)
            .foregroundColor(.gray)
            .font(.callout)
          Spacer()
        }
```

- `.filtered(years: selectedYearFilter)` 코드를 추가하면서 해당 오류 수정 완. 했습니당!

## 부리 한 마디
> **파이팅**
해야쥐

![image](https://github.com/user-attachments/assets/f166cad1-1120-479b-94fb-4db7eaf2c4b0)

