### PR TITLE
[💄UI] MainView 화면 위치 조정 / AppView tabbar 컬러 수정

### DIFF
--- a/Yanolja/Sources/App/AppView.swift
+++ b/Yanolja/Sources/App/AppView.swift
@@ -58,6 +58,7 @@ struct AppView: View {
           Text("분석")
         }
       }
+      .tint(.black)
       .navigationTitle(
         {
           switch selection {

--- a/Yanolja/Sources/Screens/Main/MainView.swift
+++ b/Yanolja/Sources/Screens/Main/MainView.swift
@@ -14,12 +14,13 @@ struct MainView: View {
   
   var body: some View {
     VStack(spacing: 0) {
+      Spacer()
+      
       WinRatePercentage(
         totalWinRate: winRateUseCase.state.totalWinRate,
         myTeam: userInfoUseCase.state.myTeam
       )
       .foregroundColor(userInfoUseCase.state.myTeam?.mainColor ?? .noTeam1)
-      .padding(.top, 20)
       .padding(.bottom, 8)
       
       MainCharacterView(


### PR DESCRIPTION
## 결론
<img src="https://github.com/user-attachments/assets/efd6c004-3d0b-45cf-a666-7be7dd8aed47" alt="Simulator Screenshot" width="300"/>

- MainView 화면 내 퍼센트/캐릭터/닉네임 위치를 중앙으로 조정하였습니당
- AppView 화면 내 tab bar 컬러를 검은색으로 수정하였습니당.

``` Swift
TabView {
      ...
}
.tint(.black)
```

## 부리 한 마디
> **구름 커식과 함께하는 수정 괴로웟습니다**
다음은 여러분이 와서 하세요.
(구름은 감형했습니다.)

![image](https://github.com/user-attachments/assets/0ebf3531-6c74-44dd-8e62-bdbec99258d9)
