### PR TITLE
[✨Feat] NicknameChangeView 시트 화면 AppView에 실행 조건 설정

### DIFF
--- a/Yanolja/Sources/App/AppView.swift
+++ b/Yanolja/Sources/App/AppView.swift
@@ -139,6 +139,14 @@ struct AppView: View {
           }
         )
       }
+      .sheet(
+        isPresented: .init(get: { userInfoUseCase.state.myTeam != nil && userInfoUseCase.state.myNickname == nil }, set: { _ in }),
+        content: {
+          NicknameChangeView(userInfoUseCase: userInfoUseCase, noNicknameUser: true)
+            .presentationDetents([.fraction(0.9)])
+        }
+      )
+      .interactiveDismissDisabled(true)
       .navigationDestination(for: NavigationDestination.self) { destination in
         switch destination {
         case .settings:

--- a/Yanolja/Sources/Domain/UseCase/UserInfoUseCase.swift
+++ b/Yanolja/Sources/Domain/UseCase/UserInfoUseCase.swift
@@ -12,7 +12,7 @@ import SwiftUI
 class UserInfoUseCase {
   struct State {
     var myTeam: BaseballTeam?
-    var myNickname: String = "기본 이름"
+    var myNickname: String?
   }
   
   enum Action {
@@ -34,7 +34,7 @@ class UserInfoUseCase {
     self.changeAppIconService = changeIconService
     self.myTeamService = myTeamService
     self.myNicknameService = myNicknameService
-    _state.myNickname = myNicknameService.readMyNickname() ?? "기본 이름"
+    _state.myNickname = myNicknameService.readMyNickname()
     _state.myTeam = myTeamService.readMyTeam()
   }
   

--- a/Yanolja/Sources/Screens/Main/MainView.swift
+++ b/Yanolja/Sources/Screens/Main/MainView.swift
@@ -77,7 +77,7 @@ private struct NameBox: View {
       }
       .foregroundStyle(.gray)
       
-      Text(userInfoUseCase.state.myNickname)
+      Text(userInfoUseCase.state.myNickname ?? "기본 이름")
         .font(.title2)
         .bold()
     }

--- a/Yanolja/Sources/Screens/Settings/NicknameChangeView.swift
+++ b/Yanolja/Sources/Screens/Settings/NicknameChangeView.swift
@@ -1,0 +1,64 @@
+//
+//  NicknameChangeView.swift
+//  Yanolja
+//
+//  Created by 박혜운 on 10/13/24.
+//  Copyright © 2024 com.mc2. All rights reserved.
+//
+
+import SwiftUI
+
+struct NicknameChangeView: View {
+  @Environment(\.dismiss) var dismiss
+  @Bindable var userInfoUseCase: UserInfoUseCase
+  @State var selectedUserNickname: String = ""
+  var noNicknameUser: Bool = false
+  
+  var body: some View {
+    VStack(spacing: 0) {
+      HStack(spacing: 0) {
+        if !noNicknameUser {
+          Button(action: {
+            dismiss()
+          }) {
+            Text("취소")
+          }
+        } else {
+          Text("취소")
+            .foregroundStyle(.clear)
+        }
+        Spacer()
+        Text("닉네임 변경")
+          .bold()
+        Spacer()
+        Button(action: {
+          userInfoUseCase.effect(.changeMyNickname(selectedUserNickname))
+          dismiss()
+        }) {
+          Text("완료")
+            .bold()
+        }
+        .disabled(selectedUserNickname.isEmpty)
+      }
+      .frame(height: 44)
+      .padding(.top, 16)
+      .padding(.bottom, 20)
+      
+      
+      if let myNickname = userInfoUseCase.state.myNickname {
+        // 지정한 닉네임이 있다면 사용하던 닉네임이 보인다
+        NicknameSettingsContent(inputText: $selectedUserNickname)
+          .onAppear {
+            selectedUserNickname = myNickname
+          }
+          .presentationDragIndicator(.visible)
+      } else {
+        // 지정한 닉네임이 없으면 그대로 실행
+        NicknameSettingsContent(inputText: $selectedUserNickname)
+          .presentationDragIndicator(.visible)
+      }
+      Spacer()
+    }
+    .padding(.horizontal, 16)
+  }
+}

--- a/Yanolja/Sources/Screens/Settings/SettingsView.swift
+++ b/Yanolja/Sources/Screens/Settings/SettingsView.swift
@@ -196,53 +196,6 @@ struct TeamChangeView: View {
   }
 }
 
-struct NicknameChangeView: View {
-  @Environment(\.dismiss) var dismiss
-  @Bindable var userInfoUseCase: UserInfoUseCase
-  @State var selectedUserNickname: String = ""
-  
-  var body: some View {
-    VStack(spacing: 0) {
-      HStack(spacing: 0) {
-        Button(action: {
-          dismiss()
-        }) {
-          Text("취소")
-        }
-        Spacer()
-        Text("닉네임 변경")
-          .bold()
-        Spacer()
-        Button(action: {
-          userInfoUseCase.effect(.changeMyNickname(selectedUserNickname))
-          dismiss()
-        }) {
-          Text("완료")
-            .bold()
-        }
-      }
-      .frame(height: 44)
-      .padding(.top, 16)
-      .padding(.bottom, 20)
-      
-      // 지정한 닉네임이 없으면 그대로 실행
-      if userInfoUseCase.state.myNickname.isEmpty {
-        NicknameSettingsContent(inputText: $selectedUserNickname)
-          .presentationDragIndicator(.visible)
-      } else {
-        // 지정한 닉네임이 있다면 사용하던 닉네임이 보인다
-        NicknameSettingsContent(inputText: $selectedUserNickname)
-          .onAppear {
-            selectedUserNickname = userInfoUseCase.state.myNickname
-          }
-          .presentationDragIndicator(.visible)
-      }
-      Spacer()
-    }
-    .padding(.horizontal, 16)
-  }
-}
-
 struct TermsView: View {
   var body: some View {
     Text("이용약관 화면")

--- a/Yanolja/Sources/Screens/Settings/SettingsView.swift
+++ b/Yanolja/Sources/Screens/Settings/SettingsView.swift
@@ -78,7 +78,7 @@ struct ContentView: View {
         }
         .clipShape(Circle())
         
-        Text("\(userInfoUseCase.state.myNickname)")
+        Text("\(userInfoUseCase.state.myNickname ?? "기본 이름")")
           .font(.title2)
           .fontWeight(.black)
           .frame(maxWidth: .infinity)


### PR DESCRIPTION
# 작업 내용 
### 1. 기존 NicknameChangeView 진입 경로 구분 (최초 진입 / 변경)
=> 최초진입 시 `변경` 아닌 `설정`으로 두는 게 좋을 것 같아용! 

### 2. UserInfoUseCase 내 닉네임 정보 옵셔널로 변경 
한번도 닉네임을 설정한 적 없는 사용자가 보기에 '기본 이름'이 먹여져 있는 상태가 어색할 것으로 판단

### 3. 기존 사용자 닉네임 변경 시트 진입 시 취소 버튼 삭제, 스와이프로 내리기 불가 

```swift 
      .sheet(
        isPresented: .init(get: { userInfoUseCase.state.myTeam != nil && userInfoUseCase.state.myNickname == nil }, set: { _ in }),
        content: {
          NicknameChangeView(userInfoUseCase: userInfoUseCase, noNicknameUser: true)
            .presentationDetents([.fraction(0.9)])
        }
      )
      .interactiveDismissDisabled(true)
```