### PR TITLE
[🔥HOTFIX] AppView tabbar tint 처리로 인해 DetailRecordView 내부 텍스트 색이 모두 검정색이 되는 문제 해결 / AllRecordView 구단별 기록 확인 시 나의 구단명이 포함되는 문제 해결

### DIFF
--- a/Yanolja/Sources/App/AppView.swift
+++ b/Yanolja/Sources/App/AppView.swift
@@ -58,7 +58,7 @@ struct AppView: View {
           Text("분석")
         }
       }
-      .tint(.black)
+      .accentColor(.black)
       .navigationTitle(
         {
           switch selection {

--- a/Yanolja/Sources/DesignSystem/Views/Record/RecordListFilterButton.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Record/RecordListFilterButton.swift
@@ -20,7 +20,7 @@ struct RecordListFilterButton: View {
         showLabel: RecordFilter.all.label
       )
       Menu(RecordFilter.teamOptions(.doosan).label) {
-        ForEach(BaseballTeam.recordBaseBallTeam, id: \.name) { team in
+        ForEach(BaseballTeam.recordBaseBallTeam.filter { $0 != myTeam }, id: \.name) { team in
           RecordFilterLabel(
             selectedRecordFilter: $selectedRecordFilter,
             recordFilter: .teamOptions(team),

--- a/Yanolja/Sources/Domain/Entity/Common/AnalyzeFilter.swift
+++ b/Yanolja/Sources/Domain/Entity/Common/AnalyzeFilter.swift
@@ -19,7 +19,7 @@ enum AnalyticsFilter: Hashable {
   var label: String {
     switch self {
     case .team:
-      return "구단별"
+      return "상대구단별"
     case .stadiums:
       return "구장별"
     }

--- a/Yanolja/Sources/Domain/Entity/Common/RecordFilter.swift
+++ b/Yanolja/Sources/Domain/Entity/Common/RecordFilter.swift
@@ -22,7 +22,7 @@ enum RecordFilter: CaseIterable, Hashable {
     case .all:
       return "전체"
     case .teamOptions:
-      return "구단별"
+      return "상대구단별"
     case .stadiumsOptions:
       return "구장별"
     case .resultsOptions:

--- a/Yanolja/Sources/Network/BaseURL.swift
+++ b/Yanolja/Sources/Network/BaseURL.swift
@@ -1,0 +1,16 @@
+//
+//  BaseURL.swift
+//  WineyNetwork
+//
+//  Created by 박혜운 on 2023/09/25.
+//  Copyright © 2023 com.adultOfNineteen. All rights reserved.
+//
+
+import Foundation
+
+public extension String {
+  // MARK: - TODO Config 파일로 넣고 private 처리
+  static var baseURL: String {
+    return "https://port-0-penum1227-2024-mc2-a11-yanolja-backend-m1whxrmt7143d77c.sel4.cloudtype.app"
+  }
+}

--- a/Yanolja/Sources/Screens/Record/AllRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/AllRecordView.swift
@@ -76,7 +76,7 @@ struct AllRecordView: View {
           }
         }
         .scrollIndicators(.never)
-        .padding(.top, 25)
+        .padding(.top, 16)
       }
     }
     .padding(.horizontal, 16)


### PR DESCRIPTION
## 문제 상황
1. AppView TabBar의 색상을 변경할 때 `.tint(.black)`을 활용하였더니, DetailRecordView 내부의 모든 텍스트 색상이 아주 쨍하게 블랙이 되었습니당 ^__^...
2. AllRecordView에서 구단별 필터를 클릭하면, 나의 구단을 포함한 구단 리스트가 보였습니당.

## 해결
1. `.accentColor(.black)`으로 수정해서 기존의 색 그대로 유지할 수 있도록 바꿨습니당.
2. AllRecordView에서 구단별 필터를 클릭하면, 나의 구단을 포함한 구단 리스트를 보여주어 필터에서 나의 구단이 보이지 않도록 조정하였습니다!
3. 2번의 결과에 따라 '구단별'이라는 워딩이 충분히 헷갈릴 수 있다고 판단, '상대구단별'로 워딩 수정하였습니당.

## 부리 한 마디
![image](https://github.com/user-attachments/assets/c7eca944-96b6-4e2a-870c-10edf9377eff)
