### PR TITLE
[🔥HOTFIX] 기록 수정, 삭제가 적절히 이루어지지 않는 문제 해결

### DIFF
--- a/Yanolja/Sources/Domain/Entity/RecordModel.swift
+++ b/Yanolja/Sources/Domain/Entity/RecordModel.swift
@@ -38,7 +38,7 @@ struct GameRecordModel: Identifiable {
 // MARK: - v1.0 이후 Record 데이터
 struct GameRecordWithScoreModel: Identifiable {
   
-  let id: UUID
+  var id: UUID
   var date: Date
   var stadiums: String
   var isDoubleHeader: Int // 추가

--- a/Yanolja/Sources/Domain/UseCase/RecordUseCase.swift
+++ b/Yanolja/Sources/Domain/UseCase/RecordUseCase.swift
@@ -87,8 +87,11 @@ class RecordUseCase {
     case let .tappedEditNewRecord(editRecord):
       _ = recordService.editRecord(editRecord)
       if let index = _state.recordList.map({ $0.id }).firstIndex(of: editRecord.id) {
+        print("123124")
         _state.recordList[index] = editRecord
+        print(_state.recordList[index])
       }
+      print(_state.recordList)
       self._state.editRecordSheet = false
       
       // 데이터 삭제 요청

--- a/Yanolja/Sources/Domain/UseCase/RecordUseCase.swift
+++ b/Yanolja/Sources/Domain/UseCase/RecordUseCase.swift
@@ -87,11 +87,8 @@ class RecordUseCase {
     case let .tappedEditNewRecord(editRecord):
       _ = recordService.editRecord(editRecord)
       if let index = _state.recordList.map({ $0.id }).firstIndex(of: editRecord.id) {
-        print("123124")
         _state.recordList[index] = editRecord
-        print(_state.recordList[index])
       }
-      print(_state.recordList)
       self._state.editRecordSheet = false
       
       // 데이터 삭제 요청

--- a/Yanolja/Sources/Screens/Record/DetailRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/DetailRecordView.swift
@@ -402,7 +402,8 @@ struct DetailRecordView: View {
     let service = GameRecordInfoService.live
     let result = await service.gameRecord(recording.date, recording.myTeam.sliceName)
     isDataLoading = false
-    guard case let .success(recordList) = result else { return [] }
+    guard case var .success(recordList) = result else { return [] }
+    recordList.indices.forEach { recordList[$0].id = recording.id }
     return recordList
   }
   
@@ -420,6 +421,7 @@ struct DetailRecordView: View {
 private extension GameRecordWithScoreModel {
   func keepMemoPhoto(in exRecord: GameRecordWithScoreModel) -> GameRecordWithScoreModel {
     var new = self
+    new.id = exRecord.id
     new.memo = exRecord.memo
     new.photo = exRecord.photo
     


### PR DESCRIPTION
#문제 원인 
서버로부터 새로운 기록을 가져와 대입하면서 외부 기록이 들어오게 되었고,
이 과정에서 `id`의 고유성을 잃는 문제가 발생 

삽입과 삭제는 `id`를 통해 이루어지는데 해당 id가 내려 받은 Model 객체의 id로 변경되면서 CoreData와의 불일치 발생. 

#해결 
### id 값이 유지되도록 가져온 기록에 대해 id값 나의 id로 변경 후 주입 
```swift
private func loadRealGameRecordsInfo() async -> [GameRecordWithScoreModel] {
    isDataLoading = true
    let service = GameRecordInfoService.live
    let result = await service.gameRecord(recording.date, recording.myTeam.sliceName)
    isDataLoading = false
    guard case var .success(recordList) = result else { return [] }
    recordList.indices.forEach { recordList[$0].id = recording.id } // 추가 
    return recordList
  }
```
### 값 변경시 사진, 메모에 더불어 id도 유지되도록 변경 
```swift 
private extension GameRecordWithScoreModel {
  func keepMemoPhoto(in exRecord: GameRecordWithScoreModel) -> GameRecordWithScoreModel {
    var new = self
    new.id = exRecord.id
    new.memo = exRecord.memo
    new.photo = exRecord.photo
    
    return new
  }
}
```