### PR TITLE
[🔥HOTFIX] 사진 삭제후 복귀되는 문제 해결 / 직관기록 없는 경우 필터 별 설명 문구 / 승률 정보 갱신 실패시 nil / 말풍선 통신 실패 시 기본 값 적용 / 모든 시트 버튼 블랙 

### DIFF
--- a/Yanolja/Sources/Data/Services/RecordDataService.swift
+++ b/Yanolja/Sources/Data/Services/RecordDataService.swift
@@ -108,6 +108,8 @@ class RecordDataService: RecordDataServiceInterface {
                 // UIImage -> Data 변환 후 저장
                 if let photo = record.photo {
                     recordToEdit.photo = photo.jpegData(compressionQuality: 1.0)
+                } else {
+                  recordToEdit.photo = nil // 사진이 없을 경우 기존 데이터를 삭제
                 }
                 
                 try recordContext.save()

--- a/Yanolja/Sources/Domain/Entity/Common/BaseballTeam.swift
+++ b/Yanolja/Sources/Domain/Entity/Common/BaseballTeam.swift
@@ -23,6 +23,8 @@ enum BaseballTeam: String, CaseIterable {
   case noTeam
   
   static let recordBaseBallTeam: [Self] = [.doosan, .lotte, .samsung, .hanwha, .kiwoom, .kia, .kt, .lg, .nc, .ssg]
+  
+  static let defaultBubbleTexts: [String] = ["오늘은 누구 응원할까?", "내가 혹시 승리요정??", "어느 구단으로 취직하지?", "이기는 팀 우리 팀?", "홈런 가자!?"]
 }
 
 extension BaseballTeam {

--- a/Yanolja/Sources/Domain/UseCase/UserInfoUseCase.swift
+++ b/Yanolja/Sources/Domain/UseCase/UserInfoUseCase.swift
@@ -59,8 +59,10 @@ class UserInfoUseCase {
       
     case .setBubbleTexts:
       Task {
-        if case let .success(bubbleTextList) = await settingsService.characterBubbleTexts(_state.myTeam?.sliceName ?? "두산") {
+        if case let .success(bubbleTextList) = await settingsService.characterBubbleTexts(_state.myTeam?.sliceName ?? BaseballTeam.noTeam.sliceName) {
           _state.bubbleTextList = bubbleTextList
+        } else {
+          _state.bubbleTextList = BaseballTeam.defaultBubbleTexts
         }
       }
       

--- a/Yanolja/Sources/Domain/UseCase/WinRateUseCase.swift
+++ b/Yanolja/Sources/Domain/UseCase/WinRateUseCase.swift
@@ -86,6 +86,8 @@ class WinRateUseCase {
       Task {
         if case let .success(winRate) = await gameRecordInfoService.teamWinRate(_state.myTeam.sliceName) {
           _state.myTeamWinRate = winRate
+        } else {
+          _state.myTeamWinRate = nil
         }
       }
       

--- a/Yanolja/Sources/Screens/Analyze/AnalyticsDetailView.swift
+++ b/Yanolja/Sources/Screens/Analyze/AnalyticsDetailView.swift
@@ -62,7 +62,7 @@ struct AnalyticsDetailView: View {
   }
   
   var body: some View {
-
+    
     NavigationStack {
       VStack(spacing: 0) {
         HStack {
@@ -102,13 +102,10 @@ struct AnalyticsDetailView: View {
           }
           
           VStack(alignment: .leading, spacing: 8) {
-            if let recordCount {
-              Text("총 \(String(recordCount))경기")
-                .font(.footnote)
-            } else {
-              Text("총 --경기")
-                .font(.footnote)
-            }
+            
+            Text("총 \(String(recordCount ?? 0))경기")
+              .font(.footnote)
+            
             HStack {
               Spacer()
               // 각 팀의 승무패 횟수

--- a/Yanolja/Sources/Screens/Analyze/AnalyticsDetailView.swift
+++ b/Yanolja/Sources/Screens/Analyze/AnalyticsDetailView.swift
@@ -135,7 +135,7 @@ struct AnalyticsDetailView: View {
       if filteredRecordList.isEmpty {
         HStack{
           Spacer()
-          Text("\(detailOptions)와의 직관 기록이 없습니다.")
+          Text("\(detailOptions)와의 직관 기록이 없습니다")
             .foregroundColor(.gray)
             .font(.callout)
             .padding(.bottom, 12)

--- a/Yanolja/Sources/Screens/Record/AllRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/AllRecordView.swift
@@ -49,7 +49,18 @@ struct AllRecordView: View {
         .sortByLatestDate(isAscending).isEmpty {
         HStack{
           Spacer()
-          Text("직관 기록이 없습니다. \n직관 기록을 추가하세요!")
+          Group {
+            switch selectedRecordFilter {
+            case .all:
+              Text("\(RecordFilter.all.label) 직관 기록이 없습니다 \n직관 기록을 추가하세요!")
+            case .teamOptions(let baseballTeam):
+              Text("\(baseballTeam.sliceName) 상대 직관 기록이 없습니다 \n직관 기록을 추가하세요!")
+            case .stadiumsOptions(let string):
+              Text("\(string) 직관 기록이 없습니다 \n직관 기록을 추가하세요!")
+            case .resultsOptions(let gameResult):
+              Text("\(gameResult.label) 직관 기록이 없습니다 \n직관 기록을 추가하세요!")
+            }
+          }
             .multilineTextAlignment(.center)
             .foregroundColor(.gray)
             .font(.callout)

--- a/Yanolja/Sources/Screens/Record/DetailRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/DetailRecordView.swift
@@ -92,7 +92,7 @@ struct DetailRecordView: View {
                         
                       },
                   secondaryButton:
-                      .default(Text("확인")) {
+                      .default( Text("확인") ) {
                         // MARK: - 나의 팀 변경: 동시에 상태 팀 선택 리스트 제한
                         if let myTeam = changeMyTeam {
                           recording.myTeam = myTeam
@@ -362,6 +362,7 @@ struct DetailRecordView: View {
           }
         }
       )
+      .tint(.black)
       .navigationTitle("오늘의 직관")
       .navigationBarTitleDisplayMode(.inline)
     }

--- a/Yanolja/Sources/Screens/Settings/SettingsView.swift
+++ b/Yanolja/Sources/Screens/Settings/SettingsView.swift
@@ -148,6 +148,7 @@ struct ContentView: View {
         NavigationLink(
           destination: {
             NoticesView(notices: userInfoUseCase.state.notices)
+              .onAppear { userInfoUseCase.effect(.setNotices) }
               .navigationTitle("공지사항")
               .navigationBarBackButtonHidden(true)
               .toolbar {

--- a/Yanolja/Sources/Screens/Settings/UserInfo/NicknameChangeView.swift
+++ b/Yanolja/Sources/Screens/Settings/UserInfo/NicknameChangeView.swift
@@ -22,6 +22,7 @@ struct NicknameChangeView: View {
             dismiss()
           }) {
             Text("취소")
+              .tint(.black)
           }
         } else {
           Text("취소")
@@ -37,6 +38,7 @@ struct NicknameChangeView: View {
         }) {
           Text("완료")
             .bold()
+            .tint(.black)
         }
         .disabled(selectedUserNickname.isEmpty)
       }

--- a/Yanolja/Sources/Screens/Settings/UserInfo/TeamChangeView.swift
+++ b/Yanolja/Sources/Screens/Settings/UserInfo/TeamChangeView.swift
@@ -22,6 +22,7 @@ struct TeamChangeView: View {
         dismiss()
       }) {
         Text("취소")
+          .tint(.black)
       }
       Spacer()
       Text("팀 변경")
@@ -36,6 +37,7 @@ struct TeamChangeView: View {
       }) {
         Text("완료")
           .bold()
+          .tint(.black)
       }
     }
     .frame(height: 44)


### PR DESCRIPTION
# 작업 내용 
## 사진 삭제 후 저장 -> 앱 끔 -> 다시 실행 -> 삭제한 사진이 살아있는 문제 
```swift 
// RecordDataService

if let photo = record.photo {
  recordToEdit.photo = photo.jpegData(compressionQuality: 1.0)
} else { // (추가)
  recordToEdit.photo = nil // 사진이 없을 경우 기존 데이터를 삭제
}
```
`else` 처리가 되어 있지 않아 발생한 문제
분기 처리 코드 삽입 

## 직관기록 없는 경우 필터 별 설명문구 기입 / 문장 끝 맺음에 '.' 삭제 
| ![image](https://github.com/user-attachments/assets/dbe6492a-ab54-4d2a-81f0-2404b73cb391) | ![image](https://github.com/user-attachments/assets/e5bea74e-60bd-4e12-946f-51439760edbd) | ![image](https://github.com/user-attachments/assets/f093326c-8477-4f94-aea3-643063a2bc39) |
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/cb6af45f-1472-4d00-82cd-34ae1110c722) | ![image](https://github.com/user-attachments/assets/eeb7eb08-4a7b-47e9-b55c-e99cf424e2ff) |  |

모든 필터 별 적용 

```swift
            switch selectedRecordFilter {
            case .all:
              Text("\(RecordFilter.all.label) 직관 기록이 없습니다 \n직관 기록을 추가하세요!")
            case .teamOptions(let baseballTeam):
              Text("\(baseballTeam.sliceName) 상대 직관 기록이 없습니다 \n직관 기록을 추가하세요!")
            case .stadiumsOptions(let string):
              Text("\(string) 직관 기록이 없습니다 \n직관 기록을 추가하세요!")
            case .resultsOptions(let gameResult):
              Text("\(gameResult.label) 직관 기록이 없습니다 \n직관 기록을 추가하세요!")
            }
```
##  승률 정보 갱신 실패시 nil 주입

```swift 
        if case let .success(winRate) = await gameRecordInfoService.teamWinRate(_state.myTeam.sliceName) {
          _state.myTeamWinRate = winRate
        } else {
          _state.myTeamWinRate = nil
        }
```

팀을 바꾼 상황에서 승률에 대한 오해소지를 없애기 위함 
(원래 77퍼였는데 팀을 바꾸고도 77퍼)

## defaultBubbleTexts 설정 및 통신 실패 시 주입
```swift 
        if case let .success(bubbleTextList) = await settingsService.characterBubbleTexts(_state.myTeam?.sliceName ?? BaseballTeam.noTeam.sliceName) {
          _state.bubbleTextList = bubbleTextList
        } else {
          _state.bubbleTextList = BaseballTeam.defaultBubbleTexts
        }
```
내가 키움 팬인데 한화를 응원하는 문장을 마주치게 하지 않기 위함 

일반적인 구성, '무직' 선택 시 고려되는 문장을 삽입 

```swift 
static let defaultBubbleTexts: [String] = ["오늘은 누구 응원할까?", "내가 혹시 승리요정??", "어느 구단으로 취직하지?", "이기는 팀 우리 팀?", "홈런 가자!?"]

```

## 공지사항 불러오기 
공지사항이 읽히지 않은 상황을 고려하여 진입 시 호출 

## 모든 시트 버튼 .black으로 변경 / 기존엔 디폴트 블루 
적용된 시트는 기록 상세 화면, 캐릭터 변경 시트, 팀 변경 시트 
| ![image](https://github.com/user-attachments/assets/0652df5b-85ff-4584-a87c-ea97ca8e970b) | ![image](https://github.com/user-attachments/assets/379ccc90-e857-431a-a67b-bd9dea931d43) | ![image](https://github.com/user-attachments/assets/2e723451-005b-4ecf-b9e3-7eeccf76d2a8) |
| --- | --- | --- |

## 상대 구단 경기 모아보기 시트에서 아무런 기록 없을 때 '--경기' -> '0경기'로 수정

```diff swift 
-            if let recordCount {
-              Text("총 \(String(recordCount))경기")
-                .font(.footnote)
-            } else {
-              Text("총 --경기")
-                .font(.footnote)
-            }
            
+            Text("총 \(String(recordCount ?? 0))경기")
+              .font(.footnote)
```

