### PR TITLE
[feat] #73 Mixpanel 분석 툴 삽입 

### DIFF
--- a/InfoPlist/Info.plist
+++ b/InfoPlist/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>MixpanelKEY</key>
+	<string>$(MIXPANEL_KEY)</string>
 	<key>BaseURL</key>
 	<string>$(BASE_URL)</string>
 	<key>UIAppFonts</key>

--- a/Plugins/Config/Plugin.swift
+++ b/Plugins/Config/Plugin.swift
@@ -1,3 +1,3 @@
-import ProjectDescription
+@preconcurrency import ProjectDescription
 
 let configPlugin = Plugin(name:"ConfigPlugin")

--- a/Plugins/Config/ProjectDescriptionHelpers/LocalHelper.swift
+++ b/Plugins/Config/ProjectDescriptionHelpers/LocalHelper.swift
@@ -2,7 +2,6 @@ import ProjectDescription
 
 extension Configuration {
   public static func build(_ type: BuildTarget, name: String = "") -> Self {
-    let buildName = type.rawValue
     switch type {
     case .release:
       return .release(
@@ -34,7 +33,9 @@ extension Path {
 }
 
 extension FileElement {
-  public static var sharedConfigPath: FileElement = "./Configs/Shared.xcconfig"
+  public static var sharedConfigPath: FileElement {
+    "./Configs/Shared.xcconfig"
+  }
 }
 
 extension Scheme {

--- a/Project.swift
+++ b/Project.swift
@@ -1,4 +1,4 @@
-import ProjectDescription
+@preconcurrency import ProjectDescription
 import ProjectDescriptionHelpers
 
 /*

--- a/Tuist/Config.swift
+++ b/Tuist/Config.swift
@@ -1,4 +1,4 @@
-import ProjectDescription
+@preconcurrency import ProjectDescription
 
 let config = Config(
     plugins: [

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -1,0 +1,8 @@
+//
+//  Dependencies.swift
+//  Config
+//
+//  Created by 박혜운 on 1/13/25.
+//
+
+@preconcurrency import ProjectDescription

--- a/Tuist/Dependencies.swift
+++ b/Tuist/Dependencies.swift
@@ -6,3 +6,9 @@
 //
 
 @preconcurrency import ProjectDescription
+
+let dependencies = Dependencies(
+  swiftPackageManager: .init([
+    .package(url: "https://github.com/mixpanel/mixpanel-swift.git", from: "3.1.0")
+  ])
+)

--- a/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Project+Templates.swift
@@ -18,6 +18,9 @@ extension Project {
       name: name,
       destinations: destinations,
       dependencies: additionalTargets.map { TargetDependency.target(name: $0) }
+      + [
+        .external(name: "Mixpanel")
+      ]
     )
     targets += additionalTargets.flatMap({
       makeFrameworkTargets(

--- a/Yanolja/Sources/App/AppDelegate.swift
+++ b/Yanolja/Sources/App/AppDelegate.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import UIKit
-import Mixpanel
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -29,8 +28,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     
-    Mixpanel.initialize(token: PrivateKey.getMixpanel ?? "")
-    TrackUserActivityManager.shared.configure(service: MixpanelService())
+    TrackUserActivityManager.shared.configure(
+      token: PrivateKey.getMixpanel ?? "",
+      service: MixpanelService()
+    )
     UserDefaultsService().save(data: true, key: .isPopGestureEnabled)
     
     Task {

--- a/Yanolja/Sources/App/AppDelegate.swift
+++ b/Yanolja/Sources/App/AppDelegate.swift
@@ -30,6 +30,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   ) -> Bool {
     
     Mixpanel.initialize(token: PrivateKey.getMixpanel ?? "")
+    TrackUserActivityManager.shared.configure(service: MixpanelService())
     UserDefaultsService().save(data: true, key: .isPopGestureEnabled)
     
     Task {

--- a/Yanolja/Sources/App/AppDelegate.swift
+++ b/Yanolja/Sources/App/AppDelegate.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import Mixpanel
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -28,6 +29,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     
+    Mixpanel.initialize(token: PrivateKey.getMixpanel ?? "")
     UserDefaultsService().save(data: true, key: .isPopGestureEnabled)
     
     Task {

--- a/Yanolja/Sources/App/AppDelegate.swift
+++ b/Yanolja/Sources/App/AppDelegate.swift
@@ -95,10 +95,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       
       // 이전 기록 삭제
       _ = historyRecordService.removeRecord(id: exRecord.id)
-      
-      self.recordUseCase.effect(.renewAllRecord)
       let recordList = recordUseCase.state.recordList
-      self.winRateUseCase.effect(.updateRecords(recordList))
+
+      await MainActor.run {
+        self.recordUseCase.effect(.renewAllRecord)
+        self.winRateUseCase.effect(.updateRecords(recordList))
+      }
     }
   }
   

--- a/Yanolja/Sources/App/AppView.swift
+++ b/Yanolja/Sources/App/AppView.swift
@@ -78,17 +78,17 @@ struct AppView: View {
               switch selection {
               case .main:
                 // MARK: - 카드 공유 생성 시 활성화
-//                HStack(alignment: .top, spacing: 16) {
-//                  Button(
-//                    action: { print("이미지 다운로드") },
-//                    label: { Image(systemName: "square.and.arrow.down")
-//                      .offset(y: -2) }
-//                  )
-                  Button(
-                    action: { path.append(NavigationDestination.settings) },
-                    label: { Image(systemName: "gearshape") }
-                  )
-//                }
+                //                HStack(alignment: .top, spacing: 16) {
+                //                  Button(
+                //                    action: { print("이미지 다운로드") },
+                //                    label: { Image(systemName: "square.and.arrow.down")
+                //                      .offset(y: -2) }
+                //                  )
+                Button(
+                  action: { path.append(NavigationDestination.settings) },
+                  label: { Image(systemName: "gearshape") }
+                )
+                //                }
               case .record:
                 HStack(alignment: .top, spacing: 16) {
                   Button(
@@ -158,19 +158,19 @@ struct AppView: View {
             winRateUseCase: winRateUseCase,
             userInfoUseCase: userInfoUseCase
           )
-            .navigationTitle("마이페이지")
-            .navigationBarBackButtonHidden(true)
-            .toolbar {
-              ToolbarItem(placement: .navigationBarLeading) {
-                Button(action: {
-                  path.removeLast()
-                }) {
-                  Image(systemName: "chevron.left")
-                    .font(.system(size: 18, weight: .semibold))
-                }
-                .tint(.black)
+          .navigationTitle("마이페이지")
+          .navigationBarBackButtonHidden(true)
+          .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+              Button(action: {
+                path.removeLast()
+              }) {
+                Image(systemName: "chevron.left")
+                  .font(.system(size: 18, weight: .semibold))
               }
+              .tint(.black)
             }
+          }
         }
       }
       .fullScreenCover(
@@ -195,9 +195,9 @@ struct AppView: View {
   
   // Mixpanel 직관 기록 버튼
   func recordButton() {
-      Mixpanel.mainInstance().track(event: "RecordButton")
-      Mixpanel.mainInstance().people.increment(property: "record_button", by: 1)
-    }
+    Mixpanel.mainInstance().track(event: "RecordButton")
+    Mixpanel.mainInstance().people.increment(property: "record_button", by: 1)
+  }
 }
 
 #Preview {

--- a/Yanolja/Sources/App/AppView.swift
+++ b/Yanolja/Sources/App/AppView.swift
@@ -32,6 +32,9 @@ struct AppView: View {
           Text("홈")
         }
         .tag(Tab.main)
+        .onAppear {
+          TrackUserActivityManager.shared.effect(.mainTabOnAppear)
+        }
         
         AllRecordView(
           winRateUseCase: winRateUseCase,

--- a/Yanolja/Sources/App/AppView.swift
+++ b/Yanolja/Sources/App/AppView.swift
@@ -7,6 +7,7 @@
 //
 
 import SwiftUI
+import Mixpanel
 
 struct AppView: View {
   @State private var path = NavigationPath()  // 네비게이션 경로 관리
@@ -92,6 +93,7 @@ struct AppView: View {
                 HStack(alignment: .top, spacing: 16) {
                   Button(
                     action: {
+                      recordButton()
                       recordUseCase
                         .effect(.tappedCreateRecordSheet(true))
                     },
@@ -190,6 +192,12 @@ struct AppView: View {
       )
     }
   }
+  
+  // Mixpanel 직관 기록 버튼
+  func recordButton() {
+      Mixpanel.mainInstance().track(event: "RecordButton")
+      Mixpanel.mainInstance().people.increment(property: "record_button", by: 1)
+    }
 }
 
 #Preview {

--- a/Yanolja/Sources/App/AppView.swift
+++ b/Yanolja/Sources/App/AppView.swift
@@ -7,7 +7,6 @@
 //
 
 import SwiftUI
-import Mixpanel
 
 struct AppView: View {
   @State private var path = NavigationPath()  // 네비게이션 경로 관리
@@ -93,7 +92,7 @@ struct AppView: View {
                 HStack(alignment: .top, spacing: 16) {
                   Button(
                     action: {
-                      recordButton()
+                      TrackUserActivityManager.shared.effect(.tappedPlusButtonToMakeRecord)
                       recordUseCase
                         .effect(.tappedCreateRecordSheet(true))
                     },
@@ -191,12 +190,6 @@ struct AppView: View {
         }
       )
     }
-  }
-  
-  // Mixpanel 직관 기록 버튼
-  func recordButton() {
-    Mixpanel.mainInstance().track(event: "RecordButton")
-    Mixpanel.mainInstance().people.increment(property: "record_button", by: 1)
   }
 }
 

--- a/Yanolja/Sources/Data/DTO/MixpanelEventDTO.swift
+++ b/Yanolja/Sources/Data/DTO/MixpanelEventDTO.swift
@@ -1,0 +1,37 @@
+//
+//  MixpanelEventDTO.swift
+//  Yanolja
+//
+//  Created by 박혜운 on 1/24/25.
+//  Copyright © 2025 com.mc2. All rights reserved.
+//
+
+import Foundation
+
+enum MixpanelDTO {
+  case tabCharacter
+  case recordButton
+  case completeButton
+  case writeMemo
+  case uploadPicture
+  
+  var event: String {
+    switch self {
+    case .tabCharacter:    "TabCharacter"
+    case .recordButton:    "RecordButton"
+    case .completeButton:  "CompleteButton"
+    case .writeMemo:       "WriteMemo"
+    case .uploadPicture:   "UploadPicture"
+    }
+  }
+  
+  var property: String {
+    switch self {
+    case .tabCharacter:    "tab_character"
+    case .recordButton:    "record_button"
+    case .completeButton:  "complete_button"
+    case .writeMemo:       "write_memo_length"
+    case .uploadPicture:   "uploaded_picture"
+    }
+  }
+}

--- a/Yanolja/Sources/Data/Services/MixpanelService.swift
+++ b/Yanolja/Sources/Data/Services/MixpanelService.swift
@@ -10,6 +10,10 @@ import Foundation
 import Mixpanel
 
 struct MixpanelService: TrackUserActivityService {
+  func initialize(token: String) {
+    Mixpanel.initialize(token: token)
+  }
+  
   func tappedMainCharacter() {
     let type = MixpanelDTO.tabCharacter
     Mixpanel.mainInstance().track(event: type.event)

--- a/Yanolja/Sources/Data/Services/MixpanelService.swift
+++ b/Yanolja/Sources/Data/Services/MixpanelService.swift
@@ -11,25 +11,30 @@ import Mixpanel
 
 struct MixpanelService: TrackUserActivityService {
   func tappedMainCharacter() {
-    Mixpanel.mainInstance().track(event: "TabCharacter")
-    Mixpanel.mainInstance().people.increment(property: "tab_character", by: 1)
+    let type = MixpanelDTO.tabCharacter
+    Mixpanel.mainInstance().track(event: type.event)
+    Mixpanel.mainInstance().people.increment(property: type.property, by: 1)
   }
   
   func tappedPlusButtonToMakeRecord() {
-    Mixpanel.mainInstance().track(event: "RecordButton")
-    Mixpanel.mainInstance().people.increment(property: "record_button", by: 1)
+    let type = MixpanelDTO.recordButton
+    Mixpanel.mainInstance().track(event: type.event)
+    Mixpanel.mainInstance().people.increment(property: type.property, by: 1)
   }
   
   func tappedConfirmButtonToRecord() {
-    Mixpanel.mainInstance().track(event: "CompleteButton")
-    Mixpanel.mainInstance().people.increment(property: "complete_button", by: 1)
+    let type = MixpanelDTO.completeButton
+    Mixpanel.mainInstance().track(event: type.event)
+    Mixpanel.mainInstance().people.increment(property: type.property, by: 1)
   }
   
   func tappedConfirmButtonWithMemo(_ count: Int) {
-    Mixpanel.mainInstance().track(event: "WriteMemo", properties: ["write_memo_length": count])
+    let type = MixpanelDTO.writeMemo
+    Mixpanel.mainInstance().track(event: type.event, properties: [type.property: count])
   }
   
   func tappedConfirmButtonWithPhoto(_ exists: Bool) {
-    Mixpanel.mainInstance().track(event: "UploadPicture", properties: ["uploaded_picture": exists])
+    let type = MixpanelDTO.uploadPicture
+    Mixpanel.mainInstance().track(event: type.event, properties: [type.property: exists])
   }
 }

--- a/Yanolja/Sources/Data/Services/MixpanelService.swift
+++ b/Yanolja/Sources/Data/Services/MixpanelService.swift
@@ -21,14 +21,15 @@ struct MixpanelService: TrackUserActivityService {
   }
   
   func tappedConfirmButtonToRecord() {
-    
+    Mixpanel.mainInstance().track(event: "CompleteButton")
+    Mixpanel.mainInstance().people.increment(property: "complete_button", by: 1)
   }
   
-  func tappedConfirmButtonWithMemo() {
-    
+  func tappedConfirmButtonWithMemo(_ count: Int) {
+    Mixpanel.mainInstance().track(event: "WriteMemo", properties: ["write_memo_length": count])
   }
   
-  func tappedConfirmButtonWithPhoto() {
-    
+  func tappedConfirmButtonWithPhoto(_ exists: Bool) {
+    Mixpanel.mainInstance().track(event: "UploadPicture", properties: ["uploaded_picture": exists])
   }
 }

--- a/Yanolja/Sources/Data/Services/MixpanelService.swift
+++ b/Yanolja/Sources/Data/Services/MixpanelService.swift
@@ -1,0 +1,31 @@
+//
+//  MixpanelService.swift
+//  Yanolja
+//
+//  Created by 박혜운 on 1/23/25.
+//  Copyright © 2025 com.mc2. All rights reserved.
+//
+
+import Foundation
+import Mixpanel
+
+struct MixpanelService: TrackUserActivityService {
+  func tappedMainCharacter() {
+  }
+  
+  func tappedPlusButtonToMakeRecord() {
+    
+  }
+  
+  func tappedConfirmButtonToRecord() {
+    
+  }
+  
+  func tappedConfirmButtonWithMemo() {
+    
+  }
+  
+  func tappedConfirmButtonWithPhoto() {
+    
+  }
+}

--- a/Yanolja/Sources/Data/Services/MixpanelService.swift
+++ b/Yanolja/Sources/Data/Services/MixpanelService.swift
@@ -16,7 +16,8 @@ struct MixpanelService: TrackUserActivityService {
   }
   
   func tappedPlusButtonToMakeRecord() {
-    
+    Mixpanel.mainInstance().track(event: "RecordButton")
+    Mixpanel.mainInstance().people.increment(property: "record_button", by: 1)
   }
   
   func tappedConfirmButtonToRecord() {

--- a/Yanolja/Sources/Data/Services/MixpanelService.swift
+++ b/Yanolja/Sources/Data/Services/MixpanelService.swift
@@ -11,6 +11,8 @@ import Mixpanel
 
 struct MixpanelService: TrackUserActivityService {
   func tappedMainCharacter() {
+    Mixpanel.mainInstance().track(event: "TabCharacter")
+    Mixpanel.mainInstance().people.increment(property: "tab_character", by: 1)
   }
   
   func tappedPlusButtonToMakeRecord() {

--- a/Yanolja/Sources/DesignSystem/Views/Main/MainCharacterWithBubbleView.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Main/MainCharacterWithBubbleView.swift
@@ -13,7 +13,7 @@ struct MainCharacterWithBubbleView: View {
   let characterModel: CharacterModel
   
   // 이벤트 기록 여부를 추적
-  @State private var hasTabCharacterTracked = false
+  @State private var trackTabCharacter = false
   
   @State private var isVisible: [Bool] = [false, false, false, false, false]
   @State private var isAnimating: [Bool] = [false, false, false, false, false]
@@ -46,8 +46,8 @@ struct MainCharacterWithBubbleView: View {
   
   func tabCharacter() {
       // 이미 이벤트가 기록된 경우 호출 차단
-      guard !hasTabCharacterTracked else { return }
-      hasTabCharacterTracked = true
+      guard !trackTabCharacter else { return }
+    trackTabCharacter = true
       
       Mixpanel.mainInstance().track(event: "TabCharacter")
       Mixpanel.mainInstance().people.increment(property: "tab_character", by: 1)

--- a/Yanolja/Sources/DesignSystem/Views/Main/MainCharacterWithBubbleView.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Main/MainCharacterWithBubbleView.swift
@@ -10,15 +10,11 @@ import SwiftUI
 import Mixpanel
 
 struct MainCharacterWithBubbleView: View {
-  let characterModel: CharacterModel
-  
-  // 이벤트 기록 여부를 추적
-  @State private var trackTabCharacter = false
-  
   @State private var isVisible: [Bool] = [false, false, false, false, false]
   @State private var isAnimating: [Bool] = [false, false, false, false, false]
   private let maxCount = 5
-  
+
+  let characterModel: CharacterModel
   let bubbleText: [String]
   
   var body: some View {
@@ -39,18 +35,9 @@ struct MainCharacterWithBubbleView: View {
       }
     }
     .onTapGesture {
-      tabCharacter()
       showNextBubble()
+      TrackUserActivityManager.shared.effect(.tappedMainCharacter)
     }
-  }
-  
-  func tabCharacter() {
-    // 이미 이벤트가 기록된 경우 호출 차단
-    guard !trackTabCharacter else { return }
-    trackTabCharacter = true
-    
-    Mixpanel.mainInstance().track(event: "TabCharacter")
-    Mixpanel.mainInstance().people.increment(property: "tab_character", by: 1)
   }
   
   func makeBubble(text: String) -> some View {

--- a/Yanolja/Sources/DesignSystem/Views/Main/MainCharacterWithBubbleView.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Main/MainCharacterWithBubbleView.swift
@@ -45,13 +45,13 @@ struct MainCharacterWithBubbleView: View {
   }
   
   func tabCharacter() {
-      // 이미 이벤트가 기록된 경우 호출 차단
-      guard !trackTabCharacter else { return }
+    // 이미 이벤트가 기록된 경우 호출 차단
+    guard !trackTabCharacter else { return }
     trackTabCharacter = true
-      
-      Mixpanel.mainInstance().track(event: "TabCharacter")
-      Mixpanel.mainInstance().people.increment(property: "tab_character", by: 1)
-    }
+    
+    Mixpanel.mainInstance().track(event: "TabCharacter")
+    Mixpanel.mainInstance().people.increment(property: "tab_character", by: 1)
+  }
   
   func makeBubble(text: String) -> some View {
     Text(text)

--- a/Yanolja/Sources/DesignSystem/Views/Main/MainCharacterWithBubbleView.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Main/MainCharacterWithBubbleView.swift
@@ -7,7 +7,6 @@
 //
 
 import SwiftUI
-import Mixpanel
 
 struct MainCharacterWithBubbleView: View {
   @State private var isVisible: [Bool] = [false, false, false, false, false]

--- a/Yanolja/Sources/DesignSystem/Views/Main/MainCharacterWithBubbleView.swift
+++ b/Yanolja/Sources/DesignSystem/Views/Main/MainCharacterWithBubbleView.swift
@@ -7,9 +7,13 @@
 //
 
 import SwiftUI
+import Mixpanel
 
 struct MainCharacterWithBubbleView: View {
   let characterModel: CharacterModel
+  
+  // 이벤트 기록 여부를 추적
+  @State private var hasTabCharacterTracked = false
   
   @State private var isVisible: [Bool] = [false, false, false, false, false]
   @State private var isAnimating: [Bool] = [false, false, false, false, false]
@@ -35,9 +39,19 @@ struct MainCharacterWithBubbleView: View {
       }
     }
     .onTapGesture {
+      tabCharacter()
       showNextBubble()
     }
   }
+  
+  func tabCharacter() {
+      // 이미 이벤트가 기록된 경우 호출 차단
+      guard !hasTabCharacterTracked else { return }
+      hasTabCharacterTracked = true
+      
+      Mixpanel.mainInstance().track(event: "TabCharacter")
+      Mixpanel.mainInstance().people.increment(property: "tab_character", by: 1)
+    }
   
   func makeBubble(text: String) -> some View {
     Text(text)

--- a/Yanolja/Sources/Domain/UseCase/Interface/TrackUserActivityService.swift
+++ b/Yanolja/Sources/Domain/UseCase/Interface/TrackUserActivityService.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 protocol TrackUserActivityService {
+  func initialize(token: String)
   func tappedMainCharacter()
   func tappedPlusButtonToMakeRecord()
   func tappedConfirmButtonToRecord()

--- a/Yanolja/Sources/Domain/UseCase/Interface/TrackUserActivityService.swift
+++ b/Yanolja/Sources/Domain/UseCase/Interface/TrackUserActivityService.swift
@@ -1,0 +1,17 @@
+//
+//  TrackUserActivityService.swift
+//  Yanolja
+//
+//  Created by 박혜운 on 1/23/25.
+//  Copyright © 2025 com.mc2. All rights reserved.
+//
+
+import Foundation
+
+protocol TrackUserActivityService {
+  func tappedMainCharacter()
+  func tappedPlusButtonToMakeRecord()
+  func tappedConfirmButtonToRecord()
+  func tappedConfirmButtonWithMemo()
+  func tappedConfirmButtonWithPhoto()
+}

--- a/Yanolja/Sources/Domain/UseCase/Interface/TrackUserActivityService.swift
+++ b/Yanolja/Sources/Domain/UseCase/Interface/TrackUserActivityService.swift
@@ -12,6 +12,6 @@ protocol TrackUserActivityService {
   func tappedMainCharacter()
   func tappedPlusButtonToMakeRecord()
   func tappedConfirmButtonToRecord()
-  func tappedConfirmButtonWithMemo()
-  func tappedConfirmButtonWithPhoto()
+  func tappedConfirmButtonWithMemo(_ count: Int)
+  func tappedConfirmButtonWithPhoto(_ exists: Bool)
 }

--- a/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
+++ b/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
@@ -34,7 +34,8 @@ class TrackUserActivityManager {
       trackService?.tappedMainCharacter()
       
     case .tappedPlusButtonToMakeRecord:
-      break
+      trackService?.tappedPlusButtonToMakeRecord()
+      
     case let .tappedConfirmButtonToRecord(memo, photo):
       break 
     }

--- a/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
+++ b/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
@@ -29,21 +29,38 @@ class TrackUserActivityManager {
   func effect(_ action: Action) {
     switch action {
     case .tappedMainCharacter:
-      guard !tappedMainCharacter else { return }
-      tappedMainCharacter = true
-      trackService?.tappedMainCharacter()
+      trackMainCharacterTapped()
       
     case .tappedPlusButtonToMakeRecord:
-      trackService?.tappedPlusButtonToMakeRecord()
+      trackPlusButtonTapped()
       
     case let .tappedConfirmButtonToRecord(recording):
-      trackService?.tappedConfirmButtonToRecord()
-      
-      if let memo = recording.memo {
-        trackService?.tappedConfirmButtonWithMemo(memo.count)
-      }
-      
-      trackService?.tappedConfirmButtonWithPhoto(recording.photo != nil)
+      trackConfirmButtonTapped()
+      trackConfirmButton(withMemo: recording.memo)
+      trackConfirmButton(withPhotoExists: recording.photo != nil)
     }
+  }
+  
+  private func trackMainCharacterTapped() {
+    guard !tappedMainCharacter else { return }
+    tappedMainCharacter = true
+    trackService?.tappedMainCharacter()
+  }
+  
+  private func trackPlusButtonTapped() {
+    trackService?.tappedPlusButtonToMakeRecord()
+  }
+  
+  private func trackConfirmButtonTapped() {
+    trackService?.tappedConfirmButtonToRecord()
+  }
+  
+  private func trackConfirmButton(withMemo memo: String?) {
+    guard let memo else { return }
+    trackService?.tappedConfirmButtonWithMemo(memo.count)
+  }
+  
+  private func trackConfirmButton(withPhotoExists exists: Bool) {
+    trackService?.tappedConfirmButtonWithPhoto(exists)
   }
 }

--- a/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
+++ b/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
@@ -12,7 +12,7 @@ class TrackUserActivityManager {
   enum Action {
     case tappedMainCharacter
     case tappedPlusButtonToMakeRecord
-    case tappedConfirmButtonToRecord(memo: Bool, photo: Bool)
+    case tappedConfirmButtonToRecord(recording: GameRecordWithScoreModel)
   }
   
   static var shared: TrackUserActivityManager = .init()
@@ -36,8 +36,14 @@ class TrackUserActivityManager {
     case .tappedPlusButtonToMakeRecord:
       trackService?.tappedPlusButtonToMakeRecord()
       
-    case let .tappedConfirmButtonToRecord(memo, photo):
-      break 
+    case let .tappedConfirmButtonToRecord(recording):
+      trackService?.tappedConfirmButtonToRecord()
+      
+      if let memo = recording.memo {
+        trackService?.tappedConfirmButtonWithMemo(memo.count)
+      }
+      
+      trackService?.tappedConfirmButtonWithPhoto(recording.photo != nil)
     }
   }
 }

--- a/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
+++ b/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
@@ -1,0 +1,38 @@
+//
+//  TrackUserActivityManager.swift
+//  Yanolja
+//
+//  Created by 박혜운 on 1/23/25.
+//  Copyright © 2025 com.mc2. All rights reserved.
+//
+
+import Foundation
+
+class TrackUserActivityManager {
+  enum Action {
+    case tappedMainCharacter
+    case tappedPlusButtonToMakeRecord
+    case tappedConfirmButtonToRecord(memo: Bool, photo: Bool)
+  }
+  
+  static var shared: TrackUserActivityManager = .init()
+  
+  private init() {}
+  
+  private var trackService: TrackUserActivityService?
+  
+  func configure(service: TrackUserActivityService) {
+    self.trackService = service
+  }
+  
+  func effect(_ action: Action) {
+    switch action {
+    case .tappedMainCharacter:
+      
+    case .tappedPlusButtonToMakeRecord:
+      break
+    case let .tappedConfirmButtonToRecord(memo, photo):
+      break 
+    }
+  }
+}

--- a/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
+++ b/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
@@ -23,7 +23,8 @@ class TrackUserActivityManager {
   private var trackService: TrackUserActivityService?
   private var tappedMainCharacter: Bool = false
   
-  func configure(service: TrackUserActivityService) {
+  func configure(token: String, service: TrackUserActivityService) {
+    service.initialize(token: token)
     self.trackService = service
   }
   

--- a/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
+++ b/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
@@ -20,6 +20,7 @@ class TrackUserActivityManager {
   private init() {}
   
   private var trackService: TrackUserActivityService?
+  private var tappedMainCharacter: Bool = false
   
   func configure(service: TrackUserActivityService) {
     self.trackService = service
@@ -28,6 +29,9 @@ class TrackUserActivityManager {
   func effect(_ action: Action) {
     switch action {
     case .tappedMainCharacter:
+      guard !tappedMainCharacter else { return }
+      tappedMainCharacter = true
+      trackService?.tappedMainCharacter()
       
     case .tappedPlusButtonToMakeRecord:
       break

--- a/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
+++ b/Yanolja/Sources/Domain/UseCase/TrackUserActivityManager.swift
@@ -10,6 +10,7 @@ import Foundation
 
 class TrackUserActivityManager {
   enum Action {
+    case mainTabOnAppear
     case tappedMainCharacter
     case tappedPlusButtonToMakeRecord
     case tappedConfirmButtonToRecord(recording: GameRecordWithScoreModel)
@@ -28,8 +29,12 @@ class TrackUserActivityManager {
   
   func effect(_ action: Action) {
     switch action {
+    case .mainTabOnAppear:
+      tappedMainCharacter = false
+      
     case .tappedMainCharacter:
       trackMainCharacterTapped()
+      tappedMainCharacter = true
       
     case .tappedPlusButtonToMakeRecord:
       trackPlusButtonTapped()
@@ -43,7 +48,6 @@ class TrackUserActivityManager {
   
   private func trackMainCharacterTapped() {
     guard !tappedMainCharacter else { return }
-    tappedMainCharacter = true
     trackService?.tappedMainCharacter()
   }
   

--- a/Yanolja/Sources/Screens/Record/DetailRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/DetailRecordView.swift
@@ -8,7 +8,6 @@
 
 import SwiftUI
 import UIKit
-import Mixpanel
 
 // 내가 보이는 뷰를 생성하거나 편집하는 enum
 enum RecordViewEditType {
@@ -344,7 +343,7 @@ struct DetailRecordView: View {
                   changeRecords(recordUseCase.state.recordList)
                   dismiss()
                 }
-                completeButton()
+                TrackUserActivityManager.shared.effect(.tappedConfirmButtonToRecord(recording: recording))
               },
               label: {
                 Text("완료")
@@ -380,42 +379,7 @@ struct DetailRecordView: View {
       }
     }
   }
-  
-  // 사진 업로드 이벤트 기록
-  func uploadPicture() {
-    // 사진이 없으면 이벤트 기록 X
-    guard recording.photo != nil else { return }
-    trackUploadPicture = true
-    
-    Mixpanel.mainInstance().track(event: "UploadPicture", properties: [
-      "uploaded_picture": trackUploadPicture
-    ])
-  }
-  
-  // 메모 기입 이벤트 기록
-  func writeMemo(_ memo: String) {
-    // 메모 내용이 없으면 이벤트 기록 X
-    guard let memo = recording.memo, !memo.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-    
-    Mixpanel.mainInstance().track(event: "WriteMemo", properties: [
-      "write_memo_length": memo.count
-    ])
-  }
-  
-  // 최종 완료 이벤트 기록
-  func completeButton() {
-    // 사진이 저장된 경우에만 이벤트 기록
-    if recording.photo != nil {
-      uploadPicture()
-    }
-    // 메모가 있는 경우에만 이벤트 기록
-    if let memo = recording.memo, !memo.isEmpty {
-      writeMemo(memo)
-    }
-    Mixpanel.mainInstance().track(event: "CompleteButton")
-    Mixpanel.mainInstance().people.increment(property: "complete_button", by: 1)
-  }
-  
+
   private var selectDate: some View {
     DatePicker(
       "날짜",

--- a/Yanolja/Sources/Screens/Record/DetailRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/DetailRecordView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import UIKit
+import Mixpanel
 
 // 내가 보이는 뷰를 생성하거나 편집하는 enum
 enum RecordViewEditType {

--- a/Yanolja/Sources/Screens/Record/DetailRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/DetailRecordView.swift
@@ -278,7 +278,7 @@ struct DetailRecordView: View {
               .onTapGesture {
                 showImagePicker.toggle()
                 // 사진 업로드 이벤트
-                uploadPicture()
+                //                uploadPicture()
               }
               .sheet(
                 isPresented: $showImagePicker,
@@ -388,6 +388,16 @@ struct DetailRecordView: View {
     
     Mixpanel.mainInstance().track(event: "UploadPicture", properties: [
       "uploaded_picture": trackUploadPicture
+    ])
+  }
+  
+  // 메모 기입 이벤트 기록
+  func writeMemo(_ memo: String) {
+    // 메모 내용이 없으면 이벤트 기록 X
+    guard let memo = recording.memo, !memo.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+    
+    Mixpanel.mainInstance().track(event: "WriteMemo", properties: [
+      "write_memo_length": memo.count
     ])
   }
   

--- a/Yanolja/Sources/Screens/Record/DetailRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/DetailRecordView.swift
@@ -278,7 +278,7 @@ struct DetailRecordView: View {
               .onTapGesture {
                 showImagePicker.toggle()
                 // 사진 업로드 이벤트
-                //                uploadPicture()
+                // uploadPicture()
               }
               .sheet(
                 isPresented: $showImagePicker,
@@ -344,6 +344,7 @@ struct DetailRecordView: View {
                   changeRecords(recordUseCase.state.recordList)
                   dismiss()
                 }
+                completeButton()
               },
               label: {
                 Text("완료")
@@ -399,6 +400,20 @@ struct DetailRecordView: View {
     Mixpanel.mainInstance().track(event: "WriteMemo", properties: [
       "write_memo_length": memo.count
     ])
+  }
+  
+  // 최종 완료 이벤트 기록
+  func completeButton() {
+    // 사진이 저장된 경우에만 이벤트 기록
+    if recording.photo != nil {
+      uploadPicture()
+    }
+    // 메모가 있는 경우에만 이벤트 기록
+    if let memo = recording.memo, !memo.isEmpty {
+      writeMemo(memo)
+    }
+    Mixpanel.mainInstance().track(event: "CompleteButton")
+    Mixpanel.mainInstance().people.increment(property: "complete_button", by: 1)
   }
   
   private var selectDate: some View {

--- a/Yanolja/Sources/Screens/Record/DetailRecordView.swift
+++ b/Yanolja/Sources/Screens/Record/DetailRecordView.swift
@@ -40,6 +40,9 @@ struct DetailRecordView: View {
   
   @State private var makeBlur: Bool = false
   
+  // 이벤트 기록 여부를 추적
+  @State private var trackUploadPicture: Bool = false
+  
   init(
     to editType: RecordViewEditType,
     record: GameRecordWithScoreModel = .init(),
@@ -274,6 +277,8 @@ struct DetailRecordView: View {
               .contentShape(Rectangle())
               .onTapGesture {
                 showImagePicker.toggle()
+                // 사진 업로드 이벤트
+                uploadPicture()
               }
               .sheet(
                 isPresented: $showImagePicker,
@@ -375,6 +380,17 @@ struct DetailRecordView: View {
     }
   }
   
+  // 사진 업로드 이벤트 기록
+  func uploadPicture() {
+    // 사진이 없으면 이벤트 기록 X
+    guard recording.photo != nil else { return }
+    trackUploadPicture = true
+    
+    Mixpanel.mainInstance().track(event: "UploadPicture", properties: [
+      "uploaded_picture": trackUploadPicture
+    ])
+  }
+  
   private var selectDate: some View {
     DatePicker(
       "날짜",
@@ -441,4 +457,3 @@ private extension GameRecordWithScoreModel {
     changeRecords: { _ in }
   )
 }
-

--- a/Yanolja/Sources/Utils/Key/PrivateKey.swift
+++ b/Yanolja/Sources/Utils/Key/PrivateKey.swift
@@ -1,0 +1,15 @@
+//
+//  PrivateKey.swift
+//  Yanolja
+//
+//  Created by 박혜운 on 1/13/25.
+//  Copyright © 2025 com.mc2. All rights reserved.
+//
+
+import Foundation
+
+enum PrivateKey {
+  static var getMixpanel: String? {
+    return Bundle.main.object(forInfoDictionaryKey: "MixpanelKEY") as? String
+  }
+}


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #73 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->
### Mixpanel SPM 설치 
Tuist에 Dependencies 추가 및 설치 완료하였습니다. 
그 과정에서 @Sendable 에러가 발생함을 확인하였고 에러를 막기 위해 기존타겟 import 시 @preconcurrency 를 표기해 주어야 했습니다.
Tuist 관련 논의 상황을 보니 아직 미해결된 문제 같습니다  [참고 Tuist GitHub](https://github.com/tuist/tuist/issues/6739)
@Sendable 관련 에러에 대한 감이 없어 관련한 내용을 찾아보고자 합니다. 

### PrivateKey 값 생성 
Mixpanel Key 값을 PrivateKey의 타입계산속성으로 읽어 옵니다. 
추후 Key 값 추가 시 아래 양식을 따라 추가하면 됩니다. 

```swift 
enum PrivateKey {
  static var getMixpanel: String? {
    return Bundle.main.object(forInfoDictionaryKey: "MixpanelKEY") as? String
  }
}
```

더불어 Key 값을 담은 Configs/Shared.xcconfig 파일 내 코드 삽입이 필요합니다. 
따로 전달하겠습니다 @penum1227 @wltnryu @ksikk 

25.01.13 월요일 현재 아래와 같이 초기화만 진행되어 있습니다 
```swift 
//AppDelegate.swift 

func application(
    _ application: UIApplication,
    didFinishLaunchingWithOptions launchOptions:
    [UIApplication.LaunchOptionsKey: Any]? = nil
  ) -> Bool {
    
    Mixpanel.initialize(token: PrivateKey.getMixpanel ?? "")
```

### 오류 창 공유 
시뮬레이터 실행 시 아래와 같은 오류 코드가 발생합니다 
<img width="945" alt="image" src="https://github.com/user-attachments/assets/871f2037-d544-48a8-9986-339c3d179d2d" />

해당 코드는 
```swift 
    Mixpanel.initialize(token: PrivateKey.getMixpanel ?? "")
```
삽입 이후 시뮬레이터 실행 시 발생하는 코드로, Mixpenel 사용에 필요한 값이 시뮬레이터 상에 존재하지 않아 발생하는 경고창이라 합니다. 
실기기 실행시 경고가 발생하지 않음을 확인하였습니다. 
어떤 값이 필요하여 해당 경고가 발생하는 지 확인 중에 있습니다 ☝️


<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->


<br>
