### PR TITLE
[feat] 메모 글자수 제한 15 -> 100

### DIFF
--- a/KeepingWinner/Sources/Domain/UseCase/EditRecordUseCase.swift
+++ b/KeepingWinner/Sources/Domain/UseCase/EditRecordUseCase.swift
@@ -191,7 +191,7 @@ final class EditRecordUseCase {
         state.record.vsTeamScore = state.record.isCancel ? "-" : "0"
         
       case let .inputMemo(memo):
-        state.record.memo = String(memo.prefix(15))
+        state.record.memo = String(memo.prefix(100))
         
       case let .selectPhoto(photo):
         state.record.photo = photo

--- a/KeepingWinner/Sources/Screens/Record/DetailRecordView.swift
+++ b/KeepingWinner/Sources/Screens/Record/DetailRecordView.swift
@@ -382,18 +382,21 @@ struct DetailRecordView: View {
   }
   
   private var inputMemoField: some View {
-    TextField("한 줄 메모를 남겨 보세요.", text: Binding(
-      get: { recordUseCase.state.record.memo ?? "" },
-      set: { recordUseCase.effect(.inputMemo($0)) }
-    ))
-    .overlay(
-      alignment: .trailing,
-      content: {
-        Text("\(recordUseCase.state.record.memo?.count ?? 0) / 15")
-          .font(.callout)
-          .foregroundStyle(Color(uiColor: .systemGray2))
+      VStack(alignment: .trailing, spacing: 0) {
+          TextEditor(
+            text: Binding(
+                get: { recordUseCase.state.record.memo ?? "" },
+                set: { recordUseCase.effect(.inputMemo($0)) }
+            )
+          )
+          
+          Text("\(recordUseCase.state.record.memo?.count ?? 0) / 100")
+            .font(.callout)
+            .foregroundStyle(Color(uiColor: .systemGray2))
+            .padding(.bottom, 5)
+            
       }
-    )
+      .frame(maxHeight: 163)
   }
 }
 


### PR DESCRIPTION
<!--
  🙌 풀 리퀘스트 제목은 아래와 같이 해주세요!
      <종류>: <이슈 번호> <제목>
      ex: [feat] #167 예약 취소 구현
  ✔️ Optional, 담당자 (자신), 라벨 설정했는지 확인하세요
-->
## About this PR
### ⚓ Related Issue
<!-- 관련된 이슈 번호를 적어주세요. -->
- #108 

<br>

### 🥥 Contents
<!-- 이 PR에서 작업한 내용에 대해 알려주세요! -->

메모 글자수 제한을 15 -> 100으로 변경합니다 
<br>

### 📸 Screenshot
<!-- 
  뷰를 그린 경우 완성된 화면의 스크린샷을 같이 첨부해주세요.
  적절한 사이즈로 첨부하는 코드 👇
  <img width="300" alt="" src="이미지URL">  
-->

메모 입력 시 높이가 늘어나며 최대 높이는 `163`으로 고정입니다. 

### 기본
<img width="238" alt="image" src="https://github.com/user-attachments/assets/86dbbad3-9faf-4a68-b9a8-960d06861f18" />

### 최대높이 
<img width="229" alt="image" src="https://github.com/user-attachments/assets/8d6891c5-8cef-4109-9f99-21abeb20b137" />

텍스트 높이가 최대높이 벗어날 시 스크롤 


<br>

## Other information 🔥
<!-- 다른 리뷰어가 참고하면 좋을 내용을 알려주세요. 기타 참고사항이 있다면 작성해줍니다. -->


<br>
